### PR TITLE
Fix: [Localization.mod] Avoid array OOB access

### DIFF
--- a/localization.mod/localization.bmx
+++ b/localization.mod/localization.bmx
@@ -220,7 +220,8 @@ Type TMaxGUILocalizationEngine
 					Case Asc("}")
 						
 						'If previous char was also a closing "}" then we're leaving a token, so interpret it.
-						If tmpPrevChar = Text[i] Then
+						'ensure tmpCount is > 0 ("{{" was found)
+						If tmpPrevChar = Text[i] and tmpCount > 0 Then
 							
 							' Retrieve the token text
 							tmpCount:-1


### PR DESCRIPTION
Before: passing "}}" as text (eg. debugger entry for a string in MaxIDE) lead to "tmpCount" becoming "0 - 1" (-1) and so "tmpOpenings[-1]" was accessed, leading to a crash of MaxIDE.

Patch ensures that "{{" was found at least once.