### PR TITLE
Fix: SetShape() for GTK to make windows move- and resizable

### DIFF
--- a/gtk3maxgui.mod/gtkgadget.bmx
+++ b/gtk3maxgui.mod/gtkgadget.bmx
@@ -810,6 +810,16 @@ Type TGTKWindow Extends TGTKContainer
 			ignoreSizeEvent = True
 		End If
 		Super.SetShape(Max(x, 0), Max(y, 0), w, h)
+
+		'actually move/resize
+		'using the ignore* saves from backupping old position
+		'and sizes before calling "SetShape()"
+		If ignoreMoveEvent Then
+			gtk_window_move(handle, x, y)
+		End If
+		If ignoreSizeEvent Then
+			gtk_window_resize(handle, w, h)
+		End If
 	End Method
 
 	Rem


### PR DESCRIPTION
After @Hezkore reported not being able to move/resize GTKWindows (so on Linux) I patched in that functionality.

Pay attention that Windows Managers on Linux can ignore these things - they are more ... "hints".

https://docs.gtk.org/gtk3/method.Window.move.html
https://docs.gtk.org/gtk3/method.Window.resize.html

For keeping it simple we also ignore the "gravity" of GTK windows, so assume a north-west gravity (0,0 is topleft).