### PR TITLE
Disable drag n drop for the HTMLView gadget on windows

### DIFF
--- a/win32maxguiex.mod/mshtmlview.cpp
+++ b/win32maxguiex.mod/mshtmlview.cpp
@@ -802,7 +802,7 @@ STDMETHODIMP CMySite2::GetOptionKeyPath(
 
 STDMETHODIMP CMySite2::GetDropTarget( 
     /* [in] */ IDropTarget __RPC_FAR *pDropTarget,
-    /* [out] */ IDropTarget __RPC_FAR *__RPC_FAR *ppDropTarget) {return E_NOTIMPL;}
+    /* [out] */ IDropTarget __RPC_FAR *__RPC_FAR *ppDropTarget) {return S_FALSE;}
 
 STDMETHODIMP CMySite2::GetExternal( /* [out] */ IDispatch __RPC_FAR *__RPC_FAR *ppDispatch) {return -1;}
 


### PR DESCRIPTION
Drag n drop isn't implemented and doesn't trigger any events and thus should be disabled IMO.