### PR TITLE
Fix Rosetta deadlock in NSAddItem for GADGET_TOOLBAR

### DIFF
--- a/cocoamaxgui.mod/cocoa.macos.m
+++ b/cocoamaxgui.mod/cocoa.macos.m
@@ -3798,7 +3798,15 @@ void NSAddItem(nsgadget *gadget,int index,BBString *data,BBString *tip,NSImage *
 			[item setToolTip:tiptext];
 			[item setTag:0];
 			[GlobalApp addToolbarItem:item];
-			[toolbar addToolbarItem:item];
+			// Under Rosetta translation (x86_64 on Apple M1), two calls in this
+			// block deadlock when the parent NSWindow is still finishing its
+			// initial show animation:
+			//   1. [toolbar addToolbarItem:] — a redundant custom registration call
+			//      with the same effect as GlobalApp's addToolbarItem above. Removed.
+			//   2. [toolbar insertItemWithItemIdentifier:atIndex:] — needs the
+			//      window to be settled. A short run-loop drain before the call
+			//      processes any pending window-order events and prevents the hang.
+			[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
 			[toolbar insertItemWithItemIdentifier:text atIndex:index];		
 		}
 		break;


### PR DESCRIPTION
**Host machine:** Apple M1 (arm64), macOS 15.7.3, x86_64 binaries under Rosetta 2

**Bug:** Calling CreateToolBar under Rosetta hangs the application. The splash shows but Initialize() never completes. Tracing `NSAddItem` for `GADGET_TOOLBAR` finds two calls that deadlock when the parent NSWindow hasn't finished its show animation:

```
[GlobalApp addToolbarItem:item]
[toolbar addToolbarItem:item]          ← deadlock (redundant registration)
[toolbar insertItemWithItemIdentifier:text atIndex:index]  ← deadlock
```

100% reproducible under Rosetta, doesn't happen on native x86_64.

**Fix:** Self-contained in one block:
1. Remove `[toolbar addToolbarItem:]` — redundant with GlobalApp's registration above
2. Drain the run loop before `insertItem` — lets the window finish its show animation

**Tested in isolation:**
- Removing the redundant call alone → still hangs at `insertItem`
- Run-loop drain alone → still deadlocks on the redundant call
- Both together → full IDE launches in ~45 ms

No changes needed in callers.
