### PR TITLE
Modernise CocoaMaxGUI for modern macOS

### DIFF
--- a/cocoamaxgui.mod/cocoa.macos.m
+++ b/cocoamaxgui.mod/cocoa.macos.m
@@ -4,17 +4,22 @@
 
 #include <AppKit/AppKit.h>
 #include <WebKit/WebView.h>
-#include <WebKit/WebFrame.h>a
+#include <WebKit/WebFrame.h>
 #include <WebKit/WebPolicyDelegate.h>
 #include <WebKit/WebFrameLoadDelegate.h>
 #include <WebKit/WebDataSource.h>
 #include <ApplicationServices/ApplicationServices.h>
+#include <stdint.h>
 
 #include <brl.mod/blitz.mod/blitz.h>
 #include <maxgui.mod/maxgui.mod/maxgui.h>
 #include <pub.mod/macos.mod/macos.h>
 
 #define STATUSBARHEIGHT 18
+
+static CGFloat MaxGUIScrollerWidth(){
+	return [NSScroller scrollerWidthForControlSize:NSControlSizeRegular scrollerStyle:NSScrollerStyleLegacy];
+}
 
 // Custom Cursor Stuff
 
@@ -50,10 +55,25 @@ void* NSActiveGadget();
 void brl_event_EmitEvent( BBObject *event );
 BBObject *maxgui_maxgui_HotKeyEvent( int key,int mods );
 void maxgui_maxgui_event_DispatchGuiEvents();
-void maxgui_cocoamaxgui_cocoagui_EmitCocoaOSEvent( NSEvent *event,void *handle,BBObject *gadget );
-int maxgui_cocoamaxgui_cocoagui_EmitCocoaMouseEvent( NSEvent *event,void *handle );
-int maxgui_cocoamaxgui_cocoagui_EmitCocoaKeyEvent( NSEvent *event,void *handle );
-#ifdef __x86_64
+void maxgui_cocoamaxgui_cocoagui_EmitCocoaOSEvent( NSEvent *event,void *handle,void *view,BBObject *gadget );
+int maxgui_cocoamaxgui_cocoagui_EmitCocoaMouseEvent( NSEvent *event,void *handle,void *view );
+int maxgui_cocoamaxgui_cocoagui_EmitCocoaKeyEvent( NSEvent *event,void *handle,void *view );
+void maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( int ev,void *treeHandle,void *nodeHandle,int mods,int x,int y );
+int maxgui_cocoamaxgui_cocoagui_PostCocoaTreeDragEvent( void *treeHandle,void *nodeHandle,int button,int mods,int x,int y );
+int maxgui_cocoamaxgui_cocoagui_PostCocoaGadgetDropEvent( void *targetHandle,int button,int mods,int x,int y );
+int maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag( int button );
+void *NSPeerForNativeHandle( void *handle );
+void NSPeerSetNativeObjects( void *peer,void *handle,void *view );
+void *NSPeerNativeHandle( void *peer );
+void *NSPeerClientView( void *peer );
+int NSPeerGadgetClass( void *peer );
+int NSPeerGadgetStyle( void *peer );
+void *NSPeerParent( void *peer );
+void NSPeerStoreTextColor( void *peer,void *color );
+void *NSPeerTextColor( void *peer );
+void NSPeerStoreFontStyle( void *peer,int style );
+int NSPeerFontStyle( void *peer );
+#if defined(__LP64__)
 void maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( int ev,void *handle,BBInt64 data,int mods,int x,int y,BBObject *extra );
 #else
 void maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( int ev,void *handle,int data,int mods,int x,int y,BBObject *extra );
@@ -64,28 +84,132 @@ int maxgui_cocoamaxgui_cocoagui_FilterKeyDown( void *handle,int key,int mods );
 
 static void EmitOSEvent( NSEvent *event,void *handle ){
 //printf("EmitOSEvent\n");fflush(stdout);
-	maxgui_cocoamaxgui_cocoagui_EmitCocoaOSEvent( event,handle,&bbNullObject );
+	void *peer=NSPeerForNativeHandle(handle);
+	maxgui_cocoamaxgui_cocoagui_EmitCocoaOSEvent( event,peer ? peer : handle,handle,&bbNullObject );
 }
 
 int HaltMouseEvents;
 
 static int EmitMouseEvent( NSEvent *event,void *handle ){
-	if(([event type] == NSScrollWheel) && ([event deltaY] == 0)) return 0;
-	if(!HaltMouseEvents) return maxgui_cocoamaxgui_cocoagui_EmitCocoaMouseEvent( event,handle );
+	if(([event type] == NSEventTypeScrollWheel) && ([event deltaY] == 0)) return 0;
+	void *peer=NSPeerForNativeHandle(handle);
+	if(!HaltMouseEvents) return maxgui_cocoamaxgui_cocoagui_EmitCocoaMouseEvent( event,peer ? peer : handle,handle );
+	return 0;
 }
 
 static int EmitKeyEvent( NSEvent *event,void *handle ){
-	return maxgui_cocoamaxgui_cocoagui_EmitCocoaKeyEvent( event,handle );
+	void *peer=NSPeerForNativeHandle(handle);
+	return maxgui_cocoamaxgui_cocoagui_EmitCocoaKeyEvent( event,peer ? peer : handle,handle );
 }
 
-#ifdef __x86_64
+#if defined(__LP64__)
 static void PostGuiEvent( int ev,void *handle,BBInt64 data,int mods,int x,int y,BBObject *extra ){
 #else
 static void PostGuiEvent( int ev,void *handle,int data,int mods,int x,int y,BBObject *extra ){
 #endif
 //printf("PostGuiEvent\n");fflush(stdout);
 	if (extra==0) extra=&bbNullObject;
-	maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( ev,handle,data,mods,x,y,extra );
+	void *peer=NSPeerForNativeHandle(handle);
+	maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( ev,peer ? peer : handle,data,mods,x,y,extra );
+}
+
+static NSPoint MaxGUIEventPointInView(NSEvent *event,NSView *view){
+	NSRect bounds=[view bounds];
+	NSPoint point=[view convertPoint:[event locationInWindow] fromView:nil];
+	point.x-=NSMinX(bounds);
+	if ([view isFlipped]) point.y-=NSMinY(bounds);
+	else point.y=NSMaxY(bounds)-point.y;
+	return point;
+}
+
+static NSPoint MaxGUIWindowPointInView(NSPoint windowPoint,NSView *view){
+	NSRect bounds=[view bounds];
+	NSPoint point=[view convertPoint:windowPoint fromView:nil];
+	point.x-=NSMinX(bounds);
+	if ([view isFlipped]) point.y-=NSMinY(bounds);
+	else point.y=NSMaxY(bounds)-point.y;
+	return point;
+}
+
+static void *MaxGUIPeerForViewHierarchy(NSView *view){
+	while (view){
+		void *peer=NSPeerForNativeHandle(view);
+		if (peer) return peer;
+		view=[view superview];
+	}
+	return 0;
+}
+
+static int MaxGUIMouseButtonForEvent(NSEvent *event){
+	NSInteger button=[event buttonNumber]+1;
+	return button>=MOUSE_LEFT && button<=MOUSE_MIDDLE ? (int)button : 0;
+}
+
+static int MaxGUIPostDropForEvent(NSEvent *event){
+	int button=MaxGUIMouseButtonForEvent(event);
+	if (!button) return 0;
+	NSWindow *eventWindow=[event window];
+	if (!eventWindow) return maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
+	NSPoint screenPoint=[eventWindow convertPointToScreen:[event locationInWindow]];
+	NSInteger windowNumber=[NSWindow windowNumberAtPoint:screenPoint belowWindowWithWindowNumber:0];
+	NSWindow *dropWindow=[NSApp windowWithWindowNumber:windowNumber];
+	if (!dropWindow) return maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
+	NSPoint windowPoint=[dropWindow convertPointFromScreen:screenPoint];
+	NSView *hitView=[[dropWindow contentView] hitTest:windowPoint];
+	void *targetPeer=MaxGUIPeerForViewHierarchy(hitView);
+	if (!targetPeer) return maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
+	NSView *targetView=(NSView*)NSPeerClientView(targetPeer);
+	if (!targetView || ![targetView isKindOfClass:[NSView class]]) return maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
+	NSPoint point=MaxGUIWindowPointInView(windowPoint,targetView);
+	int posted=maxgui_cocoamaxgui_cocoagui_PostCocoaGadgetDropEvent(targetPeer,button,bbSystemTranslateMods([event modifierFlags]),(int)point.x,(int)point.y);
+	if (!posted) maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
+	return posted;
+}
+
+static NSColor *MaxGUIRGBColor(int r,int g,int b){
+	return [NSColor colorWithSRGBRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:1.0];
+}
+
+static NSAppearance *MaxGUIAppearanceForRGBBackground(int r,int g,int b){
+	double luminance=(0.2126*r+0.7152*g+0.0722*b)/255.0;
+	NSString *name=luminance>=0.5 ? NSAppearanceNameAqua : NSAppearanceNameDarkAqua;
+	return [NSAppearance appearanceNamed:name];
+}
+
+static NSDictionary *MaxGUIFileURLReadingOptions(){
+	return [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:NSPasteboardURLReadingFileURLsOnlyKey];
+}
+
+static NSArray *MaxGUIFileURLsFromPasteboard(NSPasteboard *pasteboard){
+	return [pasteboard readObjectsForClasses:[NSArray arrayWithObject:[NSURL class]] options:MaxGUIFileURLReadingOptions()];
+}
+
+static NSDragOperation MaxGUIFileDragOperation(id <NSDraggingInfo> sender){
+	NSPasteboard *pasteboard=[sender draggingPasteboard];
+	if ([pasteboard canReadObjectForClasses:[NSArray arrayWithObject:[NSURL class]] options:MaxGUIFileURLReadingOptions()]) return NSDragOperationCopy;
+	return NSDragOperationNone;
+}
+
+static BOOL MaxGUIAcceptDroppedFiles(id window,id <NSDraggingInfo> sender){
+	NSArray *urls=MaxGUIFileURLsFromPasteboard([sender draggingPasteboard]);
+	void *peer=NSPeerForNativeHandle(window);
+	NSView *view=(NSView*)(peer ? NSPeerClientView(peer) : [window contentView]);
+	NSPoint point=MaxGUIWindowPointInView([sender draggingLocation],view);
+	for (NSURL *url in urls){
+		NSString *path=[url path];
+		if (!path) continue;
+		BBString *name=bbStringFromNSString(path);
+		PostGuiEvent(BBEVENT_WINDOWACCEPT,window,0,0,(int)point.x,(int)point.y,(BBObject*)name);
+	}
+	return [urls count]>0;
+}
+
+int NSMaxGUIFileURLPasteboardItemRoundTrip(){
+	NSString *expected=@"/tmp";
+	NSPasteboardItem *item=[[[NSPasteboardItem alloc] init] autorelease];
+	if (![item setString:[[NSURL fileURLWithPath:expected] absoluteString] forType:NSPasteboardTypeFileURL]) return 0;
+	NSURL *url=[NSURL URLWithString:[item stringForType:NSPasteboardTypeFileURL]];
+	return [url isFileURL] && [[url path] isEqualToString:expected] ? 1 : 0;
 }
 
 static int filterKeyDownEvent( NSEvent *event,id source ){
@@ -93,7 +217,8 @@ static int filterKeyDownEvent( NSEvent *event,id source ){
 	NSString *ch;
 	key=bbSystemTranslateKey( [event keyCode] );
 	mods=bbSystemTranslateMods( [event modifierFlags] );
-	res=maxgui_cocoamaxgui_cocoagui_FilterKeyDown( source,key,mods );
+	void *peer=NSPeerForNativeHandle(source);
+	res=maxgui_cocoamaxgui_cocoagui_FilterKeyDown( peer ? peer : source,key,mods );
 	if (res==0) return 0;
 	ch=[event characters];
 	sz=[ch length];
@@ -104,7 +229,7 @@ static int filterKeyDownEvent( NSEvent *event,id source ){
 			case 127:key=8;break;
 			case 63272:key=127;break;
 		}
-		res=maxgui_cocoamaxgui_cocoagui_FilterChar( source,key,mods );
+		res=maxgui_cocoamaxgui_cocoagui_FilterChar( peer ? peer : source,key,mods );
 		if (res==0) return 0;
 	}
 	return 1;
@@ -112,41 +237,7 @@ static int filterKeyDownEvent( NSEvent *event,id source ){
 
 void NSRelease( NSObject *obj ){[obj release];}
 
-typedef struct nsgadget nsgadget;
-
-void NSClearItems(nsgadget *gadget);
-
-struct nsgadget{
-// BBObject
-	BBClass*	clas;
-	//int			refs;
-// gadget
-	BBObject	*target;	
-	nsgadget	*group;
-	BBObject	*kidlist;
-	int			x,y,w,h;
-	BBString		*textarg;
-	void			*extra;
-	int			style, sensitivity;
-	int			visible,total;
-	int			lockl,lockr,lockt,lockb;
-	int			lockx,locky,lockw,lockh,lockcw,lockch;
-	void			*filter,*context;
-	void			*items;
-	int			*arrPrevSelection;
-	BBObject		*datasource;
-	void			*datakeys;//$[]
-// nsGadget
-	int			internalclass, origclass;
-	id			handle;		
-	NSView		*view;
-	NSColor		*textcolor;
-	int 			intFontStyle;
-};
-
 // prototypes
-
-void NSSetSelection(nsgadget *gadget,int pos,int length,int units);
 
 @class CocoaApp;
 @class FlippedView;
@@ -159,16 +250,17 @@ void NSSetSelection(nsgadget *gadget,int pos,int length,int units);
 @class TabView;
 @class WindowView;
 @class ImageString;
+@class MaxGUIItemCellView;
 @class TableView;
 @class ToolView;
 @class Scroller;
 
-@interface CocoaApp:NSObject{
-	NSMutableDictionary	*toolbaritems;
+@interface CocoaApp:NSObject <NSWindowDelegate,NSTextFieldDelegate,NSComboBoxDelegate,NSToolbarItemValidation>{
 	NSMutableArray		*menuitems;
 }
 -(id)init;
-+(void)delayedGadgetAction:(NSNotification*)n;
++(void)delayedGadgetAction:(NSObject*)o;
++(void)scheduleGadgetAction:(NSObject*)o;
 +(void)dispatchGuiEvents;
 -(BOOL)windowShouldClose:(id)sender;
 -(void)windowDidResize:(NSNotification *)aNotification;
@@ -182,10 +274,6 @@ void NSSetSelection(nsgadget *gadget,int pos,int length,int units);
 -(void)buttonPush:(id)sender;
 -(void)textEdit:(id)sender;
 -(void)comboBoxSelectionDidChange:(NSNotification *)notification;
--(void)addToolbarItem:(NSToolbarItem *)item;
--(NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag;
--(NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar;
--(NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar;
 -(BOOL)validateToolbarItem:(NSToolbarItem *)theItem;
 -(void)addMenuItem:(NSMenuItem *)item;
 -(void)removeMenuItem:(NSMenuItem *)item;
@@ -215,13 +303,10 @@ void ScheduleEventDispatch(){
 @interface PanelView:NSBox{
 	int			style;
 	int			enabled;
-	nsgadget		*gadget;
 }
--(BOOL)isFlipped;
 -(BOOL)mouseDownCanMoveWindow;
 -(void)setColor:(NSColor*)rgb;
 -(void)setAlpha:(float)alpha;
--(void)setGadget:(nsgadget*)_gadget;
 -(void)setStyle:(int)s;
 -(void)setImage:(NSImage *)image withFlags:(int)flags;
 -(BOOL)acceptsFirstResponder;
@@ -243,6 +328,8 @@ void ScheduleEventDispatch(){
 -(void)setAlpha:(float)alpha;
 -(void)setImage:(NSImage *)image withFlags:(int)flags;
 -(void)drawRect:(NSRect)rect;
+-(BOOL)hasColor;
+-(void)dealloc;
 @end
 
 @interface CanvasView:PanelView{
@@ -252,12 +339,12 @@ void ScheduleEventDispatch(){
 -(BOOL)becomeFirstResponder;
 @end
 
-@interface ListView:NSScrollView{
+@interface ListView:NSScrollView <NSTableViewDataSource,NSTableViewDelegate>{
 	TableView *table;
 	NSTableColumn *column;
-	NSBrowserCell *cell;
 	NSMutableArray *items;
-	NSDictionary	*textstyle;
+	NSColor *textColor;
+	NSFont *font;
 }
 -(id)initWithFrame:(NSRect)rect;
 -(id)table;
@@ -265,24 +352,33 @@ void ScheduleEventDispatch(){
 -(void)removeItemAtIndex:(int)index;
 -(void)setColor:(NSColor*)color;
 -(void)setTextColor:(NSColor*)color;
--(int)numberOfRowsInTableView:(NSTableView *)aTableView;
--(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(int)rowIndex;
--(BOOL)tableView:(NSTableView *)tableView shouldEditTableColumn:(NSTableColumn *)tableColumn row:(int)rowIndex;
+-(NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView;
+-(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex;
+-(NSView *)tableView:(NSTableView *)aTableView viewForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex;
+-(BOOL)tableView:(NSTableView *)tableView shouldEditTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex;
 -(void)clear;
 -(void)addItem:(NSString*)text atIndex:(unsigned)index withImage:(NSImage*)image withTip:(NSString*)tip withExtra:(BBObject*)extra;
 -(void)setItem:(NSString*)text atIndex:(unsigned)index withImage:(NSImage*)image withTip:(NSString*)tip withExtra:(BBObject*)extra;
 -(void)selectItem:(unsigned)index;
 -(void)deselectItem:(unsigned)index;
 -(void)tableViewSelectionDidChange:(NSNotification *)aNotification;
--(void)tableView:(NSTableView *)aTableView willDisplayCell:(id)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(int)rowIndex;
 -(void)setEnabled:(BOOL)flag;
 -(BOOL)isEnabled;
+-(BOOL)configureRowView:(MaxGUIItemCellView *)rowView atRow:(NSInteger)rowIndex;
+-(void)updateVisibleRows;
 -(void)updateWidthForString:(ImageString *) string;
 -(void)updateWidth;
 -(void)queueWidthUpdate;
 -(void)dealloc;
 -(void)setFont:(NSFont*)font;
--(NSString *)view:(NSView *)view stringForToolTip:(NSToolTipTag)tag point:(NSPoint)point userData:( void  *)data;
+-(BOOL)performDoubleActionAtIndex:(NSInteger)index;
+-(void)doubleClick:(id)sender;
+@end
+
+@interface MaxGUIItemCellView:NSTableCellView{
+}
+-(id)initWithIdentifier:(NSString *)identifier;
+-(void)layout;
 @end
 
 @interface TableView:NSTableView{
@@ -291,14 +387,16 @@ void ScheduleEventDispatch(){
 @end
 
 @interface OutlineView:NSOutlineView{
+	id pressedItem;
+	int pressedButton;
+	BOOL dragPosted;
 }
 -(NSMenu*)menuForEvent:(NSEvent *)theEvent;
+-(void)prepareDragWithEvent:(NSEvent *)event button:(int)button;
+-(void)postDragWithEvent:(NSEvent *)event button:(int)button;
+-(void)clearDrag;
 @end
 
-@interface VerticalCenterAlignedBrowserCell : NSBrowserCell {
-}
-
-@end
 @interface NodeItem:NSObject{
 	TreeView		*owner;
 	NodeItem		*parent;
@@ -309,6 +407,7 @@ void ScheduleEventDispatch(){
 -(void)dealloc;
 -(id)initWithTitle:(NSString*)text;
 -(void)updateWidth;
+-(void)queueWidthUpdate;
 -(void)setOwner:(TreeView*)treeview;
 -(id)getOwner;
 -(void)show;
@@ -323,41 +422,51 @@ void ScheduleEventDispatch(){
 -(unsigned)count;
 @end
 
-@interface TreeView:NSScrollView{
+@interface TreeView:NSScrollView <NSOutlineViewDataSource,NSOutlineViewDelegate>{
 @public
 	NSOutlineView	*outline;
 	NSTableColumn	*column,*colin;
-	VerticalCenterAlignedBrowserCell	*cell;
 	NodeItem		*rootNode;
-	NSMutableDictionary *textstyle;
+	NSColor *textColor;
+	NSFont *font;
+	int suppressSelectionEvents;
 }
 -(id)initWithFrame:(NSRect)rect;
--(void)reloadItem:(id)item;
 -(void)refresh;
--(int)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item;
--(id)outlineView:(NSOutlineView*)outlineView child:(int)index ofItem:(id)item;
+-(NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item;
+-(id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(id)item;
 -(BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item;
 -(id)outlineView:(NSOutlineView*)outlineView objectValueForTableColumn:(NSTableColumn*)tableColumn byItem:(id)item;
+-(NSView *)outlineView:(NSOutlineView *)outlineView viewForTableColumn:(NSTableColumn *)tableColumn item:(id)item;
 -(unsigned)count;
 -(id)rootNode;
 -(id)selectedNode;
 -(void)selectNode:(id)node;
 -(void)expandNode:(id)node;
 -(void)collapseNode:(id)node;
+-(void)reconcileCollapsedNode:(id)node;
 -(void)outlineViewItemDidExpand:(NSNotification *)notification;
 -(void)outlineViewItemDidCollapse:(NSNotification *)notification;
 -(void)outlineViewSelectionDidChange:(NSNotification *)notification;
 -(BOOL)outlineView:(NSOutlineView *)outlineView shouldEditTableColumn:(NSTableColumn *)tableColumn item:(id)item;
--(void)outlineView:(NSOutlineView *)outlineView willDisplayCell:(id)dcell forTableColumn:(NSTableColumn *)tableColumn item:(id)item;
 -(void)setColor:(NSColor*)color;
+-(void)setExplicitColor:(NSColor*)color appearance:(NSAppearance*)appearance;
+-(void)removeColor;
 -(void)setTextColor:(NSColor*)color;
 -(void)setFont:(NSFont*)font;
 -(void)setEnabled:(BOOL)e;
 -(BOOL)isEnabled;
+-(void)configureRowView:(MaxGUIItemCellView *)rowView forNode:(NodeItem *)node;
+-(void)updateVisibleRows;
 -(void)dealloc;
+-(BOOL)performDoubleActionAtIndex:(NSInteger)index;
+-(void)doubleClick:(id)sender;
+-(BOOL)performUserSelectionAtIndex:(NSInteger)index;
+-(BOOL)performUserExpansionAtIndex:(NSInteger)index expand:(BOOL)expand;
+-(BOOL)isItemExpandedAtIndex:(NSInteger)index;
 @end
 
-@interface TextView:NSTextView{
+@interface TextView:NSTextView <NSTextViewDelegate,NSTextStorageDelegate>{
 	@public
 	NSScrollView	*scroll;
 	NSMutableParagraphStyle *style;
@@ -366,6 +475,7 @@ void ScheduleEventDispatch(){
 	
 	int lockedNest;
 	NSRange lockedRange;
+	int programmaticChangeNest;
 }
 -(NSSize)contentSize;
 -(id)storage;
@@ -375,6 +485,8 @@ void ScheduleEventDispatch(){
 -(void)setWordWrap:(BOOL)flag;
 -(void)setTabs:(int)tabs;
 -(void)setMargins:(int)leftmargin;
+-(void)beginProgrammaticChange;
+-(void)endProgrammaticChange;
 -(void)setText:(NSString*)text;
 -(void)addText:(NSString*)text;
 -(void)setScrollFrame:(NSRect)rect;
@@ -392,30 +504,62 @@ void ScheduleEventDispatch(){
 -(void)free;
 @end
 
-@interface TabView:NSTabView{
-	id		client;
+@interface TabStripScrollView:NSScrollView
+@end
+
+@interface TabSegmentedControl:NSSegmentedControl
+@end
+
+@interface TabView:NSTabView <NSTabViewDelegate>{
+	NSView		*client;
+	TabStripScrollView *tabScroll;
+	TabSegmentedControl *segments;
+	NSButton *scrollLeft;
+	NSButton *scrollRight;
 	int		user;
 }
 -(id)initWithFrame:(NSRect)rect;
 -(id)clientView;
+-(NSRect)contentRect;
+-(void)layout;
+-(CGFloat)naturalSegmentWidth;
+-(NSRect)rectForSegment:(NSInteger)index;
+-(void)synchronizeSegments;
+-(void)revealSelectedSegment;
+-(void)updateScrollButtons;
+-(void)scrollTabsLeft:(id)sender;
+-(void)scrollTabsRight:(id)sender;
+-(void)scrollBy:(CGFloat)distance;
+-(void)segmentSelected:(id)sender;
+-(void)insertTabViewItem:(NSTabViewItem *)tabViewItem atIndex:(NSInteger)index;
+-(void)removeTabViewItem:(NSTabViewItem *)tabViewItem;
+-(void)removeAllItemsForFree;
+-(void)setEnabled:(BOOL)enabled;
+-(BOOL)isEnabled;
 -(void)setFrame:(NSRect)frameRect;
 -(void)selectTabViewItemAtIndex:(int)index;
+-(BOOL)performUserSelectionAtIndex:(NSInteger)index;
 -(BOOL)tabView:(NSTabView *)tabView shouldSelectTabViewItem:(NSTabViewItem *)tabViewItem;
+-(void)tabView:(NSTabView *)tabView didSelectTabViewItem:(NSTabViewItem *)tabViewItem;
+-(NSTabViewItem *)tabViewItemAtPoint:(NSPoint)point;
+-(void)setFont:(NSFont *)font;
+-(int)overflowPresentation;
 -(void)dealloc;
 @end
 
 @interface WindowView:NSWindow{
 	id	view;
 	id	label[3];
-	nsgadget *gadget;
+	int gadgetStyle;
 	int enabled;
 	int zooming;
 	NSView *dragging;
 }
 -(id)textFirstResponder;
--(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withGadget:(nsgadget*)_gadget ;
+-(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withStyle:(int)style;
 -(id)clientView;
 -(void)setStatus:(NSString*)text align:(int)pos;
+-(id)statusLabelAtIndex:(NSInteger)index;
 -(void)sendEvent:(NSEvent*)event;
 -(NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender;
 -(BOOL)performDragOperation:(id <NSDraggingInfo>)sender;
@@ -434,15 +578,16 @@ void ScheduleEventDispatch(){
 @interface ToolView:NSPanel{
 	id	view;
 	id	label[3];
-	nsgadget *gadget;
+	int gadgetStyle;
 	int enabled;
 	int zooming;
 	NSView *dragging;
 }
 -(id)textFirstResponder;
--(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withGadget:(nsgadget*)_gadget ;
+-(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withStyle:(int)style;
 -(id)clientView;
 -(void)setStatus:(NSString*)text align:(int)pos;
+-(id)statusLabelAtIndex:(NSInteger)index;
 -(void)sendEvent:(NSEvent*)event;
 -(NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender;
 -(BOOL)performDragOperation:(id <NSDraggingInfo>)sender;
@@ -460,8 +605,224 @@ void ScheduleEventDispatch(){
 
 static CocoaApp *GlobalApp;
 
+enum {
+	MAXGUI_APP_MENU_NONE=0,
+	MAXGUI_APP_MENU_ABOUT=1,
+	MAXGUI_APP_MENU_PREFERENCES=2,
+	MAXGUI_APP_MENU_QUIT=3
+};
+
+enum {
+	MAXGUI_TOP_MENU_NONE=0,
+	MAXGUI_TOP_MENU_VIEW=1,
+	MAXGUI_TOP_MENU_WINDOW=2,
+	MAXGUI_TOP_MENU_HELP=3
+};
+
+typedef struct MaxGUIApplicationMenuBinding {
+	SEL action;
+	NSMenuItem *standardItem;
+	NSMenuItem *mappedItem;
+	NSInteger index;
+} MaxGUIApplicationMenuBinding;
+
+static NSMenu *MaxGUIAppMenu;
+static MaxGUIApplicationMenuBinding MaxGUIAppMenuBindings[4];
+static NSMutableDictionary *MaxGUITopMenuProxies;
+
+static NSValue *MaxGUITopMenuProxyKey(NSMenuItem *item){
+	return [NSValue valueWithPointer:item];
+}
+
+static void MaxGUIRegisterTopMenuProxy(NSMenuItem *item,NSMenu *menu){
+	if (!MaxGUITopMenuProxies) MaxGUITopMenuProxies=[[NSMutableDictionary alloc] init];
+	[MaxGUITopMenuProxies setObject:menu forKey:MaxGUITopMenuProxyKey(item)];
+}
+
+static NSMenu *MaxGUITopMenuProxy(NSMenuItem *item){
+	return [MaxGUITopMenuProxies objectForKey:MaxGUITopMenuProxyKey(item)];
+}
+
+static NSString *MaxGUICanonicalMenuTitle(NSString *title){
+	if (!title) return @"";
+	NSString *canonical=[[title stringByReplacingOccurrencesOfString:@"&" withString:@""] lowercaseString];
+	canonical=[canonical stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	while ([canonical hasSuffix:@"."] || [canonical hasSuffix:@"…"]){
+		canonical=[canonical substringToIndex:[canonical length]-1];
+		canonical=[canonical stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+	}
+	return canonical;
+}
+
+static int MaxGUIApplicationMenuRole(NSString *title){
+	NSString *canonical=MaxGUICanonicalMenuTitle(title);
+	if ([canonical hasPrefix:@"{{"] && [canonical hasSuffix:@"}}"]){
+		if ([canonical isEqualToString:@"{{menu_about}}"] ||
+			[canonical isEqualToString:@"{{menu_help_aboutmaxide}}"]) return MAXGUI_APP_MENU_ABOUT;
+		if ([canonical isEqualToString:@"{{menu_preferences}}"] ||
+			[canonical isEqualToString:@"{{menu_options}}"] ||
+			[canonical isEqualToString:@"{{menu_file_ideoptions}}"]) return MAXGUI_APP_MENU_PREFERENCES;
+		if ([canonical isEqualToString:@"{{menu_quit}}"] ||
+			[canonical isEqualToString:@"{{menu_exit}}"] ||
+			[canonical isEqualToString:@"{{menu_file_exit}}"]) return MAXGUI_APP_MENU_QUIT;
+	}
+	if ([canonical isEqualToString:@"about"] || [canonical hasPrefix:@"about "]) return MAXGUI_APP_MENU_ABOUT;
+	if ([canonical isEqualToString:@"preferences"] || [canonical hasPrefix:@"preferences "] ||
+		[canonical isEqualToString:@"settings"] || [canonical isEqualToString:@"options"] ||
+		[canonical isEqualToString:@"ide options"]) return MAXGUI_APP_MENU_PREFERENCES;
+	if ([canonical isEqualToString:@"quit"] || [canonical hasPrefix:@"quit "] ||
+		[canonical isEqualToString:@"exit"] || [canonical hasPrefix:@"exit "]) return MAXGUI_APP_MENU_QUIT;
+	return MAXGUI_APP_MENU_NONE;
+}
+
+static int MaxGUITopLevelMenuRole(NSString *title){
+	NSString *canonical=MaxGUICanonicalMenuTitle(title);
+	if ([canonical hasPrefix:@"{{"] && [canonical hasSuffix:@"}}"]){
+		if ([canonical isEqualToString:@"{{menu_view}}"]) return MAXGUI_TOP_MENU_VIEW;
+		if ([canonical isEqualToString:@"{{menu_window}}"]) return MAXGUI_TOP_MENU_WINDOW;
+		if ([canonical isEqualToString:@"{{menu_help}}"]) return MAXGUI_TOP_MENU_HELP;
+	}
+	if ([canonical isEqualToString:@"view"]) return MAXGUI_TOP_MENU_VIEW;
+	if ([canonical isEqualToString:@"window"]) return MAXGUI_TOP_MENU_WINDOW;
+	if ([canonical isEqualToString:@"help"]) return MAXGUI_TOP_MENU_HELP;
+	return MAXGUI_TOP_MENU_NONE;
+}
+
+static void MaxGUIInitializeApplicationMenuBindings(){
+	if (!MaxGUIAppMenuBindings[MAXGUI_APP_MENU_ABOUT].action){
+		MaxGUIAppMenuBindings[MAXGUI_APP_MENU_ABOUT].action=@selector(orderFrontStandardAboutPanel:);
+		MaxGUIAppMenuBindings[MAXGUI_APP_MENU_PREFERENCES].action=@selector(showPreferences:);
+		MaxGUIAppMenuBindings[MAXGUI_APP_MENU_QUIT].action=@selector(terminate:);
+	}
+}
+
+static NSMenuItem *MaxGUIItemWithAction(NSMenu *menu,SEL action){
+	for (NSMenuItem *item in [menu itemArray]) if ([item action]==action) return item;
+	return nil;
+}
+
+static NSMenu *MaxGUIApplicationMenu(){
+	if (MaxGUIAppMenu) return MaxGUIAppMenu;
+	MaxGUIInitializeApplicationMenuBindings();
+	for (NSMenuItem *root in [[NSApp mainMenu] itemArray]){
+		NSMenu *submenu=[root submenu];
+		if (submenu && (MaxGUIItemWithAction(submenu,@selector(orderFrontStandardAboutPanel:)) ||
+			MaxGUIItemWithAction(submenu,@selector(terminate:)))){
+			MaxGUIAppMenu=submenu;
+			break;
+		}
+	}
+	return MaxGUIAppMenu;
+}
+
+static BOOL MaxGUIMapApplicationMenuItem(NSMenuItem *item,int role){
+	if (role<=MAXGUI_APP_MENU_NONE || role>MAXGUI_APP_MENU_QUIT) return NO;
+	NSMenu *appMenu=MaxGUIApplicationMenu();
+	if (!appMenu) return NO;
+	MaxGUIApplicationMenuBinding *binding=&MaxGUIAppMenuBindings[role];
+	if (binding->mappedItem) return NO;
+	NSMenuItem *standard=MaxGUIItemWithAction(appMenu,binding->action);
+	if (!standard) return NO;
+	binding->index=[appMenu indexOfItem:standard];
+	binding->standardItem=[standard retain];
+	binding->mappedItem=item;
+	[item setKeyEquivalent:[standard keyEquivalent]];
+	[item setKeyEquivalentModifierMask:[standard keyEquivalentModifierMask]];
+	[appMenu removeItem:standard];
+	if ([item menu]) [[item menu] removeItem:item];
+	[appMenu insertItem:item atIndex:MIN(binding->index,(NSInteger)[appMenu numberOfItems])];
+	return YES;
+}
+
+static BOOL MaxGUIUnmapApplicationMenuItem(NSMenuItem *item){
+	NSMenu *appMenu=MaxGUIApplicationMenu();
+	for (int role=MAXGUI_APP_MENU_ABOUT;role<=MAXGUI_APP_MENU_QUIT;role++){
+		MaxGUIApplicationMenuBinding *binding=&MaxGUIAppMenuBindings[role];
+		if (binding->mappedItem!=item) continue;
+		if ([item menu]) [[item menu] removeItem:item];
+		if (appMenu && binding->standardItem){
+			[appMenu insertItem:binding->standardItem atIndex:MIN(binding->index,(NSInteger)[appMenu numberOfItems])];
+		}
+		[binding->standardItem release];
+		binding->standardItem=nil;
+		binding->mappedItem=nil;
+		binding->index=0;
+		return YES;
+	}
+	return NO;
+}
+
+static NSMenuItem *MaxGUITopLevelItem(int role){
+	NSMenu *mainMenu=[NSApp mainMenu];
+	for (NSMenuItem *item in [mainMenu itemArray]){
+		if (role==MAXGUI_TOP_MENU_WINDOW && [item submenu]==[NSApp windowsMenu]) return item;
+		if (role==MAXGUI_TOP_MENU_HELP && [item submenu]==[NSApp helpMenu]) return item;
+		if (role==MAXGUI_TOP_MENU_VIEW && [MaxGUICanonicalMenuTitle([item title]) isEqualToString:@"view"]) return item;
+	}
+	return nil;
+}
+
+static NSInteger MaxGUIApplicationMenuInsertionIndex(){
+	NSMenu *mainMenu=[NSApp mainMenu];
+	NSInteger index=0;
+	for (NSMenuItem *item in [mainMenu itemArray]){
+		if ([item submenu]==MaxGUIApplicationMenu()) { index++; continue; }
+		if ([item submenu]==[NSApp windowsMenu] || [item submenu]==[NSApp helpMenu] ||
+			[MaxGUICanonicalMenuTitle([item title]) isEqualToString:@"view"]) return index;
+		index++;
+	}
+	return [mainMenu numberOfItems];
+}
+
+static void MaxGUIReconcileMenuItemRole(NSMenuItem *item){
+	int appRole=MaxGUIApplicationMenuRole([item title]);
+	if (appRole){
+		MaxGUIMapApplicationMenuItem(item,appRole);
+		return;
+	}
+	int topRole=MaxGUITopLevelMenuRole([item title]);
+	if (!topRole || [item menu]!=[NSApp mainMenu]) return;
+	if (topRole==MAXGUI_TOP_MENU_HELP){
+		if (![NSApp helpMenu] || [NSApp helpMenu]==[item submenu]){
+			[[NSApp mainMenu] removeItem:item];
+			[[NSApp mainMenu] addItem:item];
+			[NSApp setHelpMenu:[item submenu]];
+		}
+		return;
+	}
+	NSMenu *standardMenu=nil;
+	if (topRole==MAXGUI_TOP_MENU_WINDOW) standardMenu=[NSApp windowsMenu];
+	else {
+		for (NSMenuItem *root in [[NSApp mainMenu] itemArray]){
+			if (root!=item && [MaxGUICanonicalMenuTitle([root title]) isEqualToString:@"view"]){
+				standardMenu=[root submenu];
+				break;
+			}
+		}
+	}
+	if (!standardMenu) return;
+	[[NSApp mainMenu] removeItem:item];
+	[item setSubmenu:nil];
+	MaxGUIRegisterTopMenuProxy(item,standardMenu);
+}
+
+static void MaxGUIPrepareMenuItemForFree(NSMenuItem *item){
+	MaxGUIUnmapApplicationMenuItem(item);
+	if ([NSApp helpMenu] && [item submenu]==[NSApp helpMenu]) [NSApp setHelpMenu:nil];
+	[MaxGUITopMenuProxies removeObjectForKey:MaxGUITopMenuProxyKey(item)];
+}
+
+// WebView is intentionally retained for the final legacy release because
+// HtmlViewRun() synchronously returns a JavaScript result. WKWebView cannot
+// preserve that contract without re-entrant main-run-loop pumping.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+#endif
+
 @class HTMLView;
-@interface HTMLView:WebView{
+@interface HTMLView:WebView <WebPolicyDelegate,WebFrameLoadDelegate>{
 	int		_state, _style;
 }
 -(id)initWithFrame:(NSRect)rect;
@@ -476,7 +837,7 @@ static CocoaApp *GlobalApp;
 	[self setAutoresizingMask:NSViewNotSizable];
 	[self setPolicyDelegate:self];
 	[self setFrameLoadDelegate:self];
-	[self setUIDelegate:self];
+	[self setUIDelegate:(id<WebUIDelegate>)self];
 	[self unregisterDraggedTypes];
 	_state=0;
 	return self;
@@ -491,7 +852,7 @@ static CocoaApp *GlobalApp;
 	WebDataSource		*datasource;
 	datasource = [[self mainFrame] provisionalDataSource];
 	if(datasource==nil) datasource = [[self mainFrame] dataSource];
-	if(datasource==nil) return [[NSString alloc] initWithString:@""];
+	if(datasource==nil) return @"";
 	return [[[datasource request] URL] absoluteString];
 }
 -(void)setAddress:(NSString*)address{
@@ -515,7 +876,7 @@ static CocoaApp *GlobalApp;
 	_state=0;
 	
 	url=[[frame dataSource]initialRequest];
-	text=bbStringFromCString((char*)[[[url URL] relativePath] cString]);
+	text=bbStringFromNSString([[url URL] relativePath]);
 	
 	if(oldstate)
 		PostGuiEvent( BBEVENT_GADGETDONE,sender,0,0,0,0,(BBObject*)text );
@@ -528,7 +889,7 @@ static CocoaApp *GlobalApp;
 	_state=0;
 	
 	url=[[frame dataSource]initialRequest];
-	text=bbStringFromCString((char*)[[[url URL] relativePath] cString]);
+	text=bbStringFromNSString([[url URL] relativePath]);
 	
 	if(oldstate)
 		PostGuiEvent( BBEVENT_GADGETDONE,sender,0,0,0,0,(BBObject*)text );
@@ -542,11 +903,12 @@ static CocoaApp *GlobalApp;
 	case WebNavigationTypeLinkClicked:
 		if ((_state==0) && (_style & HTMLVIEW_NONAVIGATE)) {
 			[listener ignore];
-			text=bbStringFromCString((char*)[[[url URL] absoluteString] cString]);
+			text=bbStringFromNSString([[url URL] absoluteString]);
 			PostGuiEvent( BBEVENT_GADGETACTION,sender,0,0,0,0,(BBObject*)text );
 		}else{
 			[listener use];
 		}
+		break;
 	default:
 		[listener use];
 	}
@@ -559,32 +921,97 @@ static CocoaApp *GlobalApp;
 }
 @end
 
+@interface MaxGUIWebPolicyTestListener:NSObject <WebPolicyDecisionListener>{
+	@public
+	int useCount;
+	int ignoreCount;
+}
+@end
+@implementation MaxGUIWebPolicyTestListener
+-(void)use{useCount++;}
+-(void)ignore{ignoreCount++;}
+-(void)download{}
+@end
+
+int NSMaxGUIHTMLNonavigatePolicy(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[HTMLView class]]) return 0;
+	HTMLView *view=(HTMLView*)handle;
+	[view setStyle:HTMLVIEW_NONAVIGATE];
+	MaxGUIWebPolicyTestListener *listener=[[MaxGUIWebPolicyTestListener alloc] init];
+	NSDictionary *action=[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:WebNavigationTypeLinkClicked] forKey:WebActionNavigationTypeKey];
+	NSURLRequest *request=[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.invalid/maxgui-policy"]];
+	[view webView:view decidePolicyForNavigationAction:action request:request frame:[view mainFrame] decisionListener:listener];
+	int passed=listener->ignoreCount==1 && listener->useCount==0;
+	[listener release];
+	return passed;
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 
 //Toolbar
 
 @class Toolbar;
-@interface Toolbar:NSToolbar{
-	NSMutableDictionary	*items;
+@interface Toolbar:NSToolbar <NSToolbarDelegate>{
+	NSMutableDictionary	*itemsByIdentifier;
+	NSMutableArray		*orderedIdentifiers;
+	NSUInteger		nextItemNumber;
 }
 -(id)initWithIdentifier:(NSString *)string;
--(void)addToolbarItem:(NSToolbarItem *)item;
--(NSArray *)toolbarAllowedItemIdentifiers;
--(NSArray *)toolbarDefaultItemIdentifiers;
+-(NSString *)nextItemIdentifier;
+-(void)registerToolbarItem:(NSToolbarItem *)item atIndex:(NSInteger)index;
+-(void)registerStandardIdentifier:(NSString *)identifier atIndex:(NSInteger)index;
+-(NSToolbarItem *)registeredToolbarItemAtIndex:(NSInteger)index;
+-(void)forgetToolbarItemAtIndex:(NSInteger)index;
 @end
 @implementation Toolbar
 -(id)initWithIdentifier:(NSString *)string{
 	self=[super initWithIdentifier:string];
-	items=[[NSMutableDictionary dictionaryWithCapacity:10] retain];
+	if (self) {
+		itemsByIdentifier=[[NSMutableDictionary alloc] initWithCapacity:10];
+		orderedIdentifiers=[[NSMutableArray alloc] initWithCapacity:10];
+		nextItemNumber=0;
+	}
 	return self;
 }
--(void)addToolbarItem:(NSToolbarItem *)item{
-	[items setObject:item forKey:[item itemIdentifier]];
+-(NSString *)nextItemIdentifier{
+	NSString *identifier=[NSString stringWithFormat:@"%@.item.%lu",[self identifier],(unsigned long)nextItemNumber];
+	nextItemNumber++;
+	return identifier;
 }
--(NSArray *)toolbarAllowedItemIdentifiers{
-	return [items allValues];
+-(void)registerToolbarItem:(NSToolbarItem *)item atIndex:(NSInteger)index{
+	NSString *identifier=[item itemIdentifier];
+	[itemsByIdentifier setObject:item forKey:identifier];
+	[orderedIdentifiers insertObject:identifier atIndex:index];
 }
--(NSArray *)toolbarDefaultItemIdentifiers{
-	return [items allValues];
+-(void)registerStandardIdentifier:(NSString *)identifier atIndex:(NSInteger)index{
+	[orderedIdentifiers insertObject:identifier atIndex:index];
+}
+-(NSToolbarItem *)registeredToolbarItemAtIndex:(NSInteger)index{
+	NSString *identifier=[orderedIdentifiers objectAtIndex:index];
+	return [itemsByIdentifier objectForKey:identifier];
+}
+-(void)forgetToolbarItemAtIndex:(NSInteger)index{
+	NSString *identifier=[orderedIdentifiers objectAtIndex:index];
+	[itemsByIdentifier removeObjectForKey:identifier];
+	[orderedIdentifiers removeObjectAtIndex:index];
+}
+-(NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag{
+	return [itemsByIdentifier objectForKey:itemIdentifier];
+}
+-(NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar{
+	return [NSArray arrayWithArray:orderedIdentifiers];
+}
+-(NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar{
+	return [NSArray arrayWithArray:orderedIdentifiers];
+}
+-(void)dealloc{
+	[self setDelegate:nil];
+	[itemsByIdentifier release];
+	[orderedIdentifiers release];
+	[super dealloc];
 }
 @end
 
@@ -595,23 +1022,39 @@ static CocoaApp *GlobalApp;
 	maxgui_maxgui_event_DispatchGuiEvents();
 }
 +(void)delayedGadgetAction:(NSObject*)o{  // See controlTextDidChange
+	NSInteger selection=0;
+	if ([o isKindOfClass:[NSComboBox class]]) selection=[(NSComboBox*)o indexOfSelectedItem];
 	PostGuiEvent( BBEVENT_GADGETACTION, 
 	              o, 
-	              [o respondsToSelector:@selector(indexOfSelectedItem)] ? [o indexOfSelectedItem] : 0,
+	              selection,
 	              0,0,0,0 );
+}
++(void)scheduleGadgetAction:(NSObject*)o{
+	[NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(delayedGadgetAction:) object:o];
+	[self performSelector:@selector(delayedGadgetAction:) withObject:o afterDelay:0.0];
 }
 -(void)controlTextDidEndEditing:(NSNotification*)n{
 	PostGuiEvent( BBEVENT_GADGETLOSTFOCUS,[n object],0,0,0,0,0 );
 }
 -(void)controlTextDidChange:(NSNotification*)n{
 	NSObject *o = [n object];
-	[CocoaApp performSelector:@selector(delayedGadgetAction:) withObject:o afterDelay:0.0];
+	if ([o isKindOfClass:[NSComboBox class]]){
+		if ([(NSComboBox*)o indexOfSelectedItem]>=0) return;
+		[CocoaApp scheduleGadgetAction:o];
+		return;
+	}
+	PostGuiEvent(BBEVENT_GADGETACTION,o,0,0,0,0,0);
 }
 
 -(id)init{
-	toolbaritems=[[NSMutableDictionary dictionaryWithCapacity:10] retain];
-	menuitems=[[NSMutableArray arrayWithCapacity:10] retain];
+	self=[super init];
+	if (self) menuitems=[[NSMutableArray arrayWithCapacity:10] retain];
 	return self;
+}
+-(void)dealloc{
+	[NSObject cancelPreviousPerformRequestsWithTarget:[CocoaApp class]];
+	[menuitems release];
+	[super dealloc];
 }
 -(BOOL)windowShouldClose:(id)sender{
 	PostGuiEvent( BBEVENT_WINDOWCLOSE,sender,0,0,0,0,0 );
@@ -666,18 +1109,14 @@ static CocoaApp *GlobalApp;
 	int delta=0;
 	scroller=(NSScroller *)sender;
 	switch([scroller hitPart]){
-	case NSScrollerDecrementLine:
-		delta=-1;
-		break;
 	case NSScrollerDecrementPage:
 		delta=-2;
 		break;
-	case NSScrollerIncrementLine:
-		delta=1;
-		break;
 	case NSScrollerIncrementPage:
 		delta=2;
-		break;	
+		break;
+	default:
+		break;
 	}
 	PostGuiEvent( BBEVENT_GADGETACTION,sender,delta,0,0,0,0 );
 }
@@ -689,8 +1128,8 @@ static CocoaApp *GlobalApp;
 	PostGuiEvent( BBEVENT_GADGETACTION,sender,0,0,0,0,0 );
 }
 -(void)comboBoxSelectionDidChange:(NSNotification *)notification{
-	NSControl *o=(NSComboBox*)[notification object];
-	[CocoaApp performSelector:@selector(delayedGadgetAction:) withObject:o afterDelay:0.0];
+	NSComboBox *o=(NSComboBox*)[notification object];
+	[CocoaApp scheduleGadgetAction:o];
 }
 -(void)comboBoxSelectionIsChanging:(NSNotification *)notification{
 	
@@ -700,20 +1139,6 @@ static CocoaApp *GlobalApp;
 }
 -(void)comboBoxWillDismiss:(NSNotification *)notification{
 	HaltMouseEvents = 0;
-}
--(void)addToolbarItem:(NSToolbarItem *)item{
-	[toolbaritems setObject:item forKey:[item itemIdentifier]];
-}
--(NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag{
-	return [toolbaritems objectForKey:itemIdentifier];
-}
--(NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar{
-	Toolbar *mytoolbar=(Toolbar*)toolbar;
-	return [mytoolbar toolbarAllowedItemIdentifiers];
-}
--(NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar{
-	Toolbar *mytoolbar=(Toolbar*)toolbar;
-	return [mytoolbar toolbarDefaultItemIdentifiers];
 }
 -(BOOL)validateToolbarItem:(NSToolbarItem *)item{
 	return [item isEnabled];
@@ -731,8 +1156,8 @@ static CocoaApp *GlobalApp;
 
 @implementation Scroller
 -(id)init{
-	[super init];
-	[self setAlphaValue:.5f];		
+	self=[super init];
+	if (self) [self setAlphaValue:.5f];
 	return self;
 }
 //-(void)drawKnob{}
@@ -766,7 +1191,7 @@ static CocoaApp *GlobalApp;
 	[[self contentView] setColor:rgb];
 }
 -(void)setAlpha:(float)al{
-	[[self contentView] setAlpha:al];
+	[(PanelViewContent*)[self contentView] setAlpha:al];
 }
 -(void)setImage:(NSImage *)img withFlags:(int)flags{
 	[[self contentView] setImage:img withFlags:flags];
@@ -778,33 +1203,32 @@ static CocoaApp *GlobalApp;
 	return (enabled)?YES:NO;
 }
 -(void)setStyle:(int)s{
-	
-	gadget->sensitivity |= (s & PANEL_ACTIVE) ? (SENSITIZE_MOUSE|SENSITIZE_KEYS) : 0;
-	
 	switch ( s & (PANEL_SUNKEN|PANEL_RAISED|PANEL_GROUP) ){
 		case PANEL_GROUP:
 			[self setContentViewMargins: NSMakeSize(4.0,4.0)];
 			[self setBoxType:NSBoxPrimary];
-			[self setBorderType: NSBezelBorder];
+			[self setTransparent:NO];
 			[self setTitlePosition: NSAtTop];
 			break;
 		case PANEL_RAISED:
 		case PANEL_SUNKEN:
 			[self setContentViewMargins: NSMakeSize(0.0,0.0)];
-			[self setBoxType: NSBoxOldStyle];
-			[self setBorderType: NSLineBorder];
+			[self setBoxType:NSBoxCustom];
+			[self setBorderWidth:1.0];
+			[self setBorderColor:[NSColor separatorColor]];
+			[self setFillColor:[NSColor clearColor]];
+			[self setCornerRadius:0.0];
+			[self setTransparent:NO];
 			[self setTitlePosition: NSNoTitle];
 			break;
 		default:
 			[self setContentViewMargins: NSMakeSize(0.0,0.0)];
-			[self setBorderType: NSNoBorder];
+			[self setBoxType:NSBoxCustom];
+			[self setTransparent:YES];
 			[self setTitlePosition: NSNoTitle];
 	}
 	
 	style=s;
-}
--(void)setGadget:(nsgadget*)_gadget{
-	gadget=_gadget;
 }
 -(BOOL)mouseDownCanMoveWindow{
 	return NO;
@@ -819,6 +1243,11 @@ static CocoaApp *GlobalApp;
 -(BOOL)mouseDownCanMoveWindow{
 	return NO;
 }
+-(void)dealloc{
+	[color release];
+	[image release];
+	[super dealloc];
+}
 -(void)setColor:(NSColor *)rgb{
 	if (color){
 		[color release];
@@ -829,6 +1258,9 @@ static CocoaApp *GlobalApp;
 		[color retain];
 	}
 	[self setNeedsDisplay:YES];
+}
+-(BOOL)hasColor{
+	return color!=nil;
 }
 -(void)setImage:(NSImage *)img withFlags:(int)flags{
 	if (img) [img retain];
@@ -848,29 +1280,28 @@ static CocoaApp *GlobalApp;
 }
 -(void)drawRect:(NSRect)rect{
 	
-	NSRect dest = NSUnionRect(rect,[self frame]);
+	NSRect dest = [self bounds];
 	
 	if (color){
 		[color set];
 		if (alpha<1.0)
-			NSRectFillUsingOperation( dest,NSCompositeSourceOver );
+			NSRectFillUsingOperation(dest,NSCompositingOperationSourceOver);
 		else
 			NSRectFill( dest );
 	}
 	
 	if (image){
-		int		op,x,y,w,h;
+		NSCompositingOperation op;
+		int		x,y,w,h;
 		float	a;
 		float	m,mm;
 		NSRect	src,tile;
 
 		a=alpha;
-		op=NSCompositeSourceOver;
+		op=NSCompositingOperationSourceOver;
 		src.origin.x=0;
 		src.origin.y=0;
 		src.size=[image size];
-		[image setFlipped:YES];
-
 		switch (imageflags&(GADGETPIXMAP_ICON-1)){
 		case PANELPIXMAP_TILE:
 			tile.size=[image size];
@@ -878,7 +1309,7 @@ static CocoaApp *GlobalApp;
 				tile.origin.y=y;
 				for (x=0;x<dest.size.width;x+=src.size.width){
 					tile.origin.x=x;
-					[image drawInRect:tile fromRect:src operation:op fraction:a];
+					[image drawInRect:tile fromRect:src operation:op fraction:a respectFlipped:YES hints:nil];
 				}
 			}					
 			break;
@@ -886,7 +1317,7 @@ static CocoaApp *GlobalApp;
 			dest.origin.x=(dest.size.width-src.size.width)/2;
 			dest.origin.y=(dest.size.height-src.size.height)/2;
 			dest.size=src.size;
-			[image drawInRect:dest fromRect:src operation:op fraction:a];
+			[image drawInRect:dest fromRect:src operation:op fraction:a respectFlipped:YES hints:nil];
 			break;
 		case PANELPIXMAP_FIT:
 			m=dest.size.width/src.size.width;
@@ -896,10 +1327,10 @@ static CocoaApp *GlobalApp;
 			dest.origin.y+=(dest.size.height-src.size.height*m)/2;
 			dest.size.width=src.size.width*m;
 			dest.size.height=src.size.height*m;
-			[image drawInRect:dest fromRect:src operation:op fraction:a];
+			[image drawInRect:dest fromRect:src operation:op fraction:a respectFlipped:YES hints:nil];
 			break;
 		case PANELPIXMAP_STRETCH:
-			[image drawInRect:dest fromRect:src operation:op fraction:a];
+			[image drawInRect:dest fromRect:src operation:op fraction:a respectFlipped:YES hints:nil];
 			break;
 		case PANELPIXMAP_FIT2:
 			m = dest.size.width/dest.size.height;
@@ -912,10 +1343,9 @@ static CocoaApp *GlobalApp;
 				src.size.height = src.size.width/m;
 			}
 			
-			[image drawInRect:dest fromRect:src operation:op fraction:a];
+			[image drawInRect:dest fromRect:src operation:op fraction:a respectFlipped:YES hints:nil];
 			break;
 		}
-		[image setFlipped:NO];
 	}
 	
 	[super drawRect:rect];
@@ -935,6 +1365,23 @@ static CocoaApp *GlobalApp;
 	return [self isEnabled];
 }
 @end
+
+int NSMaxGUIPanelCacheDisplay(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[PanelView class]]) return 0;
+	NSView *content=[(PanelView*)handle contentView];
+	NSRect bounds=[content bounds];
+	if (NSIsEmptyRect(bounds)) return 0;
+	NSBitmapImageRep *bitmap=[content bitmapImageRepForCachingDisplayInRect:bounds];
+	if (!bitmap) return 0;
+	[content cacheDisplayInRect:bounds toBitmapImageRep:bitmap];
+	return [bitmap pixelsWide]>0 && [bitmap pixelsHigh]>0 ? 1 : 0;
+}
+
+int NSMaxGUIPanelContentContained(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[PanelView class]]) return 0;
+	PanelView *panel=(PanelView*)handle;
+	return NSContainsRect([panel bounds],[[panel contentView] frame]) ? 1 : 0;
+}
 
 // ImageString
 
@@ -980,19 +1427,61 @@ static CocoaApp *GlobalApp;
 -(BBObject*)extra{return _extra;}
 @end
 
+// Shared view-based row presentation for modern list controls.
+
+@implementation MaxGUIItemCellView
+-(id)initWithIdentifier:(NSString *)identifier{
+	self=[super initWithFrame:NSZeroRect];
+	if (self){
+		[self setIdentifier:identifier];
+		NSImageView *iconView=[[NSImageView alloc] initWithFrame:NSZeroRect];
+		[iconView setImageScaling:NSImageScaleProportionallyDown];
+		[self addSubview:iconView];
+		[self setImageView:iconView];
+		[iconView release];
+
+		NSTextField *label=[[NSTextField alloc] initWithFrame:NSZeroRect];
+		[label setBezeled:NO];
+		[label setDrawsBackground:NO];
+		[label setEditable:NO];
+		[label setSelectable:NO];
+		[label setLineBreakMode:NSLineBreakByTruncatingTail];
+		[self addSubview:label];
+		[self setTextField:label];
+		[label release];
+	}
+	return self;
+}
+-(void)layout{
+	[super layout];
+	NSRect bounds=[self bounds];
+	NSImageView *iconView=[self imageView];
+	NSTextField *label=[self textField];
+	CGFloat x=4.0;
+	NSImage *image=[iconView image];
+	if (image){
+		CGFloat side=MIN(16.0,MAX(0.0,bounds.size.height-2.0));
+		[iconView setHidden:NO];
+		[iconView setFrame:NSMakeRect(x,NSMidY(bounds)-side/2.0,side,side)];
+		x+=side+4.0;
+	}else{
+		[iconView setHidden:YES];
+	}
+	[label setFrame:NSMakeRect(x,0.0,MAX(0.0,bounds.size.width-x-4.0),bounds.size.height)];
+}
+@end
+
 // ListView
 
 @implementation ListView
 -(id)initWithFrame:(NSRect)rect{
-	[super initWithFrame:rect];
+	self=[super initWithFrame:rect];
+	if (!self) return nil;
 	[self setBorderType:NSNoBorder];
 	[self setHasVerticalScroller:YES];
 	[self setHasHorizontalScroller:YES];
 	[self setAutohidesScrollers:YES];
 	column=[[NSTableColumn alloc] init];
-	cell=[[NSBrowserCell alloc] init];
-	[cell setLeaf:YES];
-	[column setDataCell:cell];
 	NSSize contentSize = [self contentSize];	
 	table=[[TableView alloc] initWithFrame:NSMakeRect(0, 0,contentSize.width, contentSize.height)];
 	[table setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
@@ -1000,8 +1489,12 @@ static CocoaApp *GlobalApp;
 	[table setHeaderView:nil];	
 	[table setDataSource:self];
 	[table setDelegate:self];
+	[table setTarget:self];
+	[table setDoubleAction:@selector(doubleClick:)];
+	[table setUsesAlternatingRowBackgroundColors:NO];
 	[self setDocumentView:table];
 	[table addTableColumn:column];
+	font=[[NSFont systemFontOfSize:[NSFont systemFontSize]] retain];
 	[table sizeLastColumnToFit];
 	return self;
 }
@@ -1012,9 +1505,7 @@ static CocoaApp *GlobalApp;
 	return items;
 }
 -(void)removeItemAtIndex:(int)index{
-	ImageString *item=(ImageString*)[items objectAtIndex:index];
 	[items removeObjectAtIndex:index];
-	[item release];
 	[table reloadData];
 	[self queueWidthUpdate];
 }
@@ -1023,38 +1514,80 @@ static CocoaApp *GlobalApp;
 }
 -(void)setEnabled:(BOOL)e{
 	[table setEnabled:e];
+	[self updateVisibleRows];
 }
 -(BOOL)isEnabled{
 	return [table isEnabled];
 }
 -(void)setTextColor:(NSColor*)color{
-	if (textstyle) {[textstyle release];textstyle=nil;}
-	if (color){
-		textstyle=[NSDictionary dictionaryWithObjectsAndKeys:color,NSForegroundColorAttributeName,nil];
-		[textstyle retain];	
-	}
+	if (textColor==color) return;
+	[textColor release];
+	textColor=[color retain];
+	[self updateVisibleRows];
 }
--(int)numberOfRowsInTableView:(NSTableView *)aTableView{
+-(NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView{
 	return [items count];
 }
--(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(int)rowIndex{
+-(id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex{
+	if (rowIndex<0 || rowIndex>=[items count]) return nil;
 	return [items objectAtIndex:rowIndex];
 }
--(BOOL)tableView:(NSTableView *)tableView shouldEditTableColumn:(NSTableColumn *)tableColumn row:(int)rowIndex{ /*new from BAH*/
-	PostGuiEvent( BBEVENT_GADGETACTION,self,rowIndex,0,0,0,0 );
+-(NSView *)tableView:(NSTableView *)aTableView viewForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex{
+	static NSString *identifier=@"MaxGUIListCell";
+	MaxGUIItemCellView *rowView=(MaxGUIItemCellView*)[aTableView makeViewWithIdentifier:identifier owner:self];
+	if (!rowView) rowView=[[[MaxGUIItemCellView alloc] initWithIdentifier:identifier] autorelease];
+	[self configureRowView:rowView atRow:rowIndex];
+	return rowView;
+}
+-(BOOL)configureRowView:(MaxGUIItemCellView *)rowView atRow:(NSInteger)rowIndex{
+	if (rowIndex<0 || rowIndex>=[items count]){
+		[[rowView textField] setStringValue:@""];
+		[[rowView imageView] setImage:nil];
+		[rowView setToolTip:nil];
+		return NO;
+	}
+	id value=[items objectAtIndex:rowIndex];
+	if (![value isKindOfClass:[ImageString class]]){
+		[[rowView textField] setStringValue:@""];
+		[[rowView imageView] setImage:nil];
+		[rowView setToolTip:nil];
+		return NO;
+	}
+	ImageString *item=(ImageString*)value;
+	[[rowView textField] setStringValue:[item string] ? [item string] : @""];
+	[[rowView textField] setFont:font];
+	NSColor *color=textColor ? textColor : [NSColor controlTextColor];
+	if (![table isEnabled]) color=[NSColor disabledControlTextColor];
+	else if ([table isRowSelected:rowIndex]) color=[NSColor alternateSelectedControlTextColor];
+	[[rowView textField] setTextColor:color];
+	[[rowView imageView] setImage:[item image]];
+	[rowView setToolTip:[item description]];
+	[rowView setNeedsLayout:YES];
+	return YES;
+}
+-(void)updateVisibleRows{
+	NSRange visibleRows=[table rowsInRect:[table visibleRect]];
+	if (visibleRows.location==NSNotFound) return;
+	NSUInteger end=NSMaxRange(visibleRows);
+	for (NSUInteger row=visibleRows.location;row<end && row<[items count];row++){
+		MaxGUIItemCellView *rowView=(MaxGUIItemCellView*)[table viewAtColumn:0 row:row makeIfNecessary:NO];
+		if (rowView) [self configureRowView:rowView atRow:row];
+	}
+}
+-(BOOL)tableView:(NSTableView *)tableView shouldEditTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)rowIndex{
 	return NO;
+}
+-(BOOL)performDoubleActionAtIndex:(NSInteger)index{
+	if (![table isEnabled] || index<0 || index>=[items count]) return NO;
+	ImageString *item=(ImageString*)[items objectAtIndex:index];
+	PostGuiEvent(BBEVENT_GADGETACTION,self,index,0,0,0,[item extra]);
+	return YES;
+}
+-(void)doubleClick:(id)sender{
+	[self performDoubleActionAtIndex:[table clickedRow]];
 }
 -(void)clear{
 	[table setDelegate:nil];
-
-	ImageString *item;
-	int count,i;
-	count=[items count];
-	for (i=0;i<count;i++){
-		item=(ImageString*)[items objectAtIndex:i];
-		[item release];
-	}
-
 	[items removeAllObjects];
 	[table reloadData];
 	[table setDelegate:self];
@@ -1065,56 +1598,44 @@ static CocoaApp *GlobalApp;
 	item=[[ImageString alloc] initWithString:text image:image tip:tip extra:extra];
 	[items insertObject:item atIndex:index];
 	[self updateWidthForString:item];
+	[item release];
 	[table noteNumberOfRowsChanged];
 }
 -(void)setItem:(NSString*)text atIndex:(unsigned)index withImage:(NSImage*)image withTip:(NSString*)tip withExtra:(BBObject*)extra{
 	ImageString *item;
-	item=(ImageString*)[items objectAtIndex:index];
-	[item release];
 	item=[[ImageString alloc] initWithString:text image:image tip:tip extra:extra];
 	[items replaceObjectAtIndex:index withObject:item];
+	[item release];
 	[table reloadData];
 	[self queueWidthUpdate];
 }
 -(void)selectItem:(unsigned)index{
 	[table setDelegate:nil];
-	[table selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:NO];
+	[table selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:[table allowsMultipleSelection]];
 	[table setDelegate:self];
+	[self updateVisibleRows];
 }
 -(void)deselectItem:(unsigned)index{
 	[table setDelegate:nil];
 	[table deselectRow:index];
 	[table setDelegate:self];
+	[self updateVisibleRows];
 }
 -(void)tableViewSelectionDidChange:(NSNotification *)aNotification{/*new from BAH*/
+	[self updateVisibleRows];
         int index=[table selectedRow];
         ImageString *item=nil;
-        if (index>=0) item=(ImageString*)[items objectAtIndex:index]; else index=-1;
+	if (index>=0 && index<[items count]) item=(ImageString*)[items objectAtIndex:index]; else index=-1;
         if (item){
                 PostGuiEvent( BBEVENT_GADGETSELECT,self,index,0,0,0,[item extra]);
         }else{
                 PostGuiEvent( BBEVENT_GADGETSELECT,self,-1,0,0,0,&bbNullObject);
         }
 }
--(void)tableView:(NSTableView *)table willDisplayCell:(id)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(int)rowIndex{
-	NSString *text=[[items objectAtIndex:rowIndex] string];
-	if (textstyle){
-		NSAttributedString *atext=[[[NSAttributedString alloc] initWithString:text attributes:textstyle] autorelease];
-		[aCell setAttributedStringValue:atext];
-	}else{
-		[aCell setStringValue:text];
-	}
-	[aCell setImage:[[items objectAtIndex:rowIndex] image]];
-}
 -(void)updateWidthForString:(ImageString *) imgstring{
-	
-	NSCell*	dcell;
-	float	cellWidth;
-	
-	dcell = [column dataCell];
-	[dcell setStringValue:[imgstring string]];
-	[dcell setImage:[imgstring image]];
-	cellWidth = ((NSSize)[dcell cellSize]).width;
+	NSDictionary *attributes=[NSDictionary dictionaryWithObject:font forKey:NSFontAttributeName];
+	CGFloat cellWidth=[[imgstring string] sizeWithAttributes:attributes].width+8.0;
+	if ([imgstring image]) cellWidth+=20.0;
 
 	if([column minWidth] < cellWidth){
 		[column setMinWidth:cellWidth];
@@ -1134,54 +1655,77 @@ static CocoaApp *GlobalApp;
 	[self performSelector:@selector(updateWidth) withObject:nil afterDelay:0.0];
 }
 -(void)dealloc{
-	ImageString *item;
-	int count,i;
-	count=[items count];
-	for (i=0;i<count;i++){
-		item=(ImageString*)[items objectAtIndex:i];
-		[item release];
-	}
-
+	[NSObject cancelPreviousPerformRequestsWithTarget:self];
+	[table setDelegate:nil];
+	[table setDataSource:nil];
 	[table release];
 	[column release];
-	[cell release];
 	[items release];
-	if (textstyle) {
-		[textstyle release];
-	}
+	[textColor release];
+	[font release];
 	[super dealloc];
 }
--(void)setFont:(NSFont*)font{
-	if (font) {
+
+-(void)setFont:(NSFont*)newFont{
+	if (newFont) {
+		if (font!=newFont){
+			[newFont retain];
+			[self->font release];
+			self->font=newFont;
+		}
 		NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
-		[table setRowHeight:[layoutManager defaultLineHeightForFont:font]+2];
+		[table setRowHeight:[layoutManager defaultLineHeightForFont:newFont]+2];
 		[layoutManager release];
-		[[column dataCell] setFont:font];
-		[table reloadData];
+		[self updateVisibleRows];
 		[self updateWidth];
 	}
 }
 
 - (NSString *)tableView:(NSTableView *)aTableView toolTipForCell:(NSCell *)aCell rect:(NSRectPointer)rect 
-tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mouseLocation{
-	
+tableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)row mouseLocation:(NSPoint)mouseLocation{
+	if (row<0 || row>=[items count]) return nil;
 	return [[items objectAtIndex:row] description];
 }
 
 @end
 
+int NSMaxGUIListUsesViewBasedRows(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[ListView class]]) return 0;
+	NSTableView *table=(NSTableView*)[(ListView*)handle table];
+	if ([table numberOfRows]<1) return 0;
+	NSView *rowView=[table viewAtColumn:0 row:0 makeIfNecessary:YES];
+	[rowView layoutSubtreeIfNeeded];
+	return [rowView isKindOfClass:[MaxGUIItemCellView class]] ? 1 : 0;
+}
+
+int NSMaxGUIListDeferredLayoutPresentation(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[ListView class]]) return 0;
+	ListView *list=(ListView*)handle;
+	NSTableView *table=(NSTableView*)[list table];
+	[table reloadData];
+	[table layoutSubtreeIfNeeded];
+	MaxGUIItemCellView *rowView=[[[MaxGUIItemCellView alloc] initWithIdentifier:@"MaxGUIListDeferredCell"] autorelease];
+	int result=[list configureRowView:rowView atRow:0] ? 1 : 0;
+	NSMutableArray *models=(NSMutableArray*)[list items];
+	if (![list configureRowView:rowView atRow:[models count]]) result|=2;
+	NSView *visible=[table viewAtColumn:0 row:0 makeIfNecessary:YES];
+	if ([visible isKindOfClass:[MaxGUIItemCellView class]]) result|=4;
+	return result;
+}
+
 // TableView
 
 @implementation TableView
 -(NSMenu*)menuForEvent:(NSEvent *)theEvent{
-	int		row = -1;
-	NSPoint p=[self convertPoint:[theEvent locationInWindow] fromView:nil];
-	row = [self rowAtPoint:p];
+	NSPoint tablePoint=[self convertPoint:[theEvent locationInWindow] fromView:nil];
+	NSPoint gadgetPoint=MaxGUIEventPointInView(theEvent,[self enclosingScrollView]);
+	NSInteger row=[self rowAtPoint:tablePoint];
 
-	if (row < [self numberOfRows]) {
+	if (row>=0 && row<[self numberOfRows]) {
 		[self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
-		PostGuiEvent( BBEVENT_GADGETMENU,[self dataSource],row,0,0,0,0 );
 	}
+	else row=-1;
+	PostGuiEvent( BBEVENT_GADGETMENU,[self dataSource],row,0,(int)gadgetPoint.x,(int)gadgetPoint.y,0 );
 
 	return nil;
 }
@@ -1191,42 +1735,80 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 
 @implementation OutlineView
 -(NSMenu*)menuForEvent:(NSEvent *)theEvent{
-	id		node;
-	NSPoint p=[self convertPoint:[theEvent locationInWindow] fromView:nil];
-	int i=[self rowAtPoint:p];
-	if (i>-1 && i<[self numberOfRows]){
+	id node=nil;
+	NSPoint outlinePoint=[self convertPoint:[theEvent locationInWindow] fromView:nil];
+	NSPoint gadgetPoint=MaxGUIEventPointInView(theEvent,[self enclosingScrollView]);
+	NSInteger i=[self rowAtPoint:outlinePoint];
+	if (i>-1 && i<[self numberOfRows] && NSPointInRect(outlinePoint,[self rectOfRow:i])){
 		node=[self itemAtRow:i];
-#ifdef __x86_64
-		PostGuiEvent( BBEVENT_GADGETMENU,[self dataSource],(BBInt64)node,0,0,0,0 );	//[self superview]
-#else
-		PostGuiEvent( BBEVENT_GADGETMENU,[self dataSource],(int)node,0,0,0,0 );	//[self superview]
-#endif
 	}
+	maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( BBEVENT_GADGETMENU,NSPeerForNativeHandle([self dataSource]),node,0,(int)gadgetPoint.x,(int)gadgetPoint.y );
 	return nil;
 }
+-(void)prepareDragWithEvent:(NSEvent *)event button:(int)button{
+	pressedItem=nil;
+	pressedButton=button;
+	dragPosted=NO;
+	NSPoint point=[self convertPoint:[event locationInWindow] fromView:nil];
+	NSInteger row=[self rowAtPoint:point];
+	if (row>=0 && row<[self numberOfRows] && NSPointInRect(point,[self rectOfRow:row])) pressedItem=[self itemAtRow:row];
+}
+-(void)postDragWithEvent:(NSEvent *)event button:(int)button{
+	if (dragPosted || !pressedItem || button!=pressedButton || ![self isEnabled]) return;
+	void *treePeer=NSPeerForNativeHandle([self dataSource]);
+	if (!treePeer || !(NSPeerGadgetStyle(treePeer)&TREEVIEW_DRAGNDROP)) return;
+	NSPoint point=MaxGUIEventPointInView(event,[self enclosingScrollView]);
+	if (maxgui_cocoamaxgui_cocoagui_PostCocoaTreeDragEvent(treePeer,pressedItem,button,bbSystemTranslateMods([event modifierFlags]),(int)point.x,(int)point.y)) dragPosted=YES;
+}
+-(void)clearDrag{
+	pressedItem=nil;
+	pressedButton=0;
+	dragPosted=NO;
+}
+-(void)mouseDown:(NSEvent *)event{
+	[self prepareDragWithEvent:event button:MOUSE_LEFT];
+	[super mouseDown:event];
+}
+-(void)rightMouseDown:(NSEvent *)event{
+	[self prepareDragWithEvent:event button:MOUSE_RIGHT];
+	[super rightMouseDown:event];
+}
+-(void)otherMouseDown:(NSEvent *)event{
+	[self prepareDragWithEvent:event button:MOUSE_MIDDLE];
+	[super otherMouseDown:event];
+}
+-(void)mouseDragged:(NSEvent *)event{
+	[self postDragWithEvent:event button:MOUSE_LEFT];
+	[super mouseDragged:event];
+}
+-(void)rightMouseDragged:(NSEvent *)event{
+	[self postDragWithEvent:event button:MOUSE_RIGHT];
+	[super rightMouseDragged:event];
+}
+-(void)otherMouseDragged:(NSEvent *)event{
+	[self postDragWithEvent:event button:MOUSE_MIDDLE];
+	[super otherMouseDragged:event];
+}
+-(void)mouseUp:(NSEvent *)event{
+	[super mouseUp:event];
+	[self clearDrag];
+}
+-(void)rightMouseUp:(NSEvent *)event{
+	[super rightMouseUp:event];
+	[self clearDrag];
+}
+-(void)otherMouseUp:(NSEvent *)event{
+	[super otherMouseUp:event];
+	[self clearDrag];
+}
 @end
 
-@implementation VerticalCenterAlignedBrowserCell
-
-- (NSRect)titleRectForBounds:(NSRect)theRect {
-    NSRect titleFrame = [super titleRectForBounds:theRect];
-    NSSize titleSize = [[self attributedStringValue] size];
-	titleFrame.origin.x = theRect.origin.x + 2;
-    titleFrame.origin.y = theRect.origin.y - .5 + (theRect.size.height - titleSize.height) / 2.0;
-    return titleFrame;
-}
-
-- (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView {
-    NSRect titleRect = [self titleRectForBounds:cellFrame];
-    [[self attributedStringValue] drawInRect:titleRect];
-}
-
-@end
 // TreeView
 
 @implementation TreeView
 -(id)initWithFrame:(NSRect)rect{
-	[super initWithFrame:rect];
+	self=[super initWithFrame:rect];
+	if (!self) return nil;
 	[self setBorderType:NSNoBorder];
 	[self setHasVerticalScroller:YES];
 	[self setHasHorizontalScroller:YES];
@@ -1239,35 +1821,38 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	[outline setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
 	[outline setDataSource:self];
 	[outline setDelegate:self];
+	[outline setTarget:self];
+	[outline setDoubleAction:@selector(doubleClick:)];
 	column=[[NSTableColumn alloc] init];
 	[outline addTableColumn:column];
 	[outline setOutlineTableColumn:column];
-	cell=[[VerticalCenterAlignedBrowserCell alloc] init];
-	[cell setLeaf:YES];
-	[cell setScrollable:YES];
-	[column setDataCell:cell];		
+	font=[[NSFont systemFontOfSize:[NSFont systemFontSize]] retain];
+	suppressSelectionEvents=0;
 	[self setDocumentView:outline];
 	[outline sizeLastColumnToFit];
 	return self;
 }
 -(void)dealloc{
-	[outline autorelease];
-	[column autorelease];
-	[cell autorelease];
-	if (textstyle) {
-		[textstyle release];
-	}
+	[NSObject cancelPreviousPerformRequestsWithTarget:self];
+	[outline setDelegate:nil];
+	[outline setDataSource:nil];
+	[outline release];
+	[column release];
+	[textColor release];
+	[font release];
+	[rootNode setOwner:nil];
+	[rootNode release];
 	[super dealloc];
 }
 -(void)refresh{
 	[rootNode updateWidth];
 	[outline reloadData];
 }
--(int)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item{
+-(NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item{
 	if( !item ) item=rootNode;
 	return [[item kids] count];
 }
--(id)outlineView:(NSOutlineView*)outlineView child:(int)index ofItem:(id)item{
+-(id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(id)item{
 	if( !item ) item=rootNode;
 	if (index>=[[item kids] count]) return 0;
 	return [[item kids] objectAtIndex:index];
@@ -1279,7 +1864,35 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(id)outlineView:(NSOutlineView*)outlineView objectValueForTableColumn:(NSTableColumn*)tableColumn byItem:(id)item{
 	if (tableColumn==colin) return @"";	
 	if( !item ) item=rootNode;
-	return [item value];
+	return [(NodeItem*)item value];
+}
+-(NSView *)outlineView:(NSOutlineView *)anOutlineView viewForTableColumn:(NSTableColumn *)tableColumn item:(id)item{
+	static NSString *identifier=@"MaxGUITreeCell";
+	MaxGUIItemCellView *rowView=(MaxGUIItemCellView*)[anOutlineView makeViewWithIdentifier:identifier owner:self];
+	if (!rowView) rowView=[[[MaxGUIItemCellView alloc] initWithIdentifier:identifier] autorelease];
+	[self configureRowView:rowView forNode:(NodeItem*)item];
+	return rowView;
+}
+-(void)configureRowView:(MaxGUIItemCellView *)rowView forNode:(NodeItem *)node{
+	NSInteger row=[outline rowForItem:node];
+	[[rowView textField] setStringValue:[node value] ? [node value] : @""];
+	[[rowView textField] setFont:font];
+	NSColor *color=textColor ? textColor : [NSColor controlTextColor];
+	if (![outline isEnabled]) color=[NSColor disabledControlTextColor];
+	else if ([outline isRowSelected:row]) color=[NSColor alternateSelectedControlTextColor];
+	[[rowView textField] setTextColor:color];
+	[[rowView imageView] setImage:[node icon]];
+	[rowView setNeedsLayout:YES];
+}
+-(void)updateVisibleRows{
+	for (NSView *view in [outline subviews]){
+		if (![view isKindOfClass:[NSTableRowView class]]) continue;
+		NSInteger row=[outline rowForView:view];
+		if (row<0 || row>=[outline numberOfRows]) continue;
+		MaxGUIItemCellView *rowView=(MaxGUIItemCellView*)[(NSTableRowView*)view viewAtColumn:0];
+		NodeItem *node=(NodeItem*)[outline itemAtRow:row];
+		if (rowView && node) [self configureRowView:rowView forNode:node];
+	}
 }
 -(unsigned)count{
 	return [rootNode count];
@@ -1296,127 +1909,185 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(void)selectNode:(id)node{
 	int index;
 	[node show];
-	[outline setDelegate:nil];
 	index = [outline rowForItem:node];
+	suppressSelectionEvents++;
 	[outline selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:NO];
-	[outline setDelegate:self];
-	[outline scrollRowToVisible:index];	
+	[outline scrollRowToVisible:index];
+	suppressSelectionEvents--;
+	[self updateVisibleRows];
 }
 -(void)expandNode:(id)node{
 	[outline setDelegate:nil];
 	[outline expandItem:node];
 	[outline tile];
 	[outline setDelegate:self];
+	[self updateVisibleRows];
 	[node queueWidthUpdate];
 }
 -(void)collapseNode:(id)node{
 	[outline setDelegate:nil];
 	[outline collapseItem:node];
-	[outline tile];
+	[self reconcileCollapsedNode:node];
 	[outline setDelegate:self];
 	[rootNode queueWidthUpdate];
+}
+-(void)reconcileCollapsedNode:(id)node{
+	[outline reloadItem:node reloadChildren:YES];
+	[outline tile];
+	[outline setNeedsDisplay:YES];
+	[outline layoutSubtreeIfNeeded];
+	[self updateVisibleRows];
 }
 -(void)outlineViewItemDidExpand:(NSNotification *)notification{
 	id		node;
 	node=[[notification userInfo] objectForKey:@"NSObject"];
 	[node queueWidthUpdate];
-#ifdef __x86_64
-	PostGuiEvent( BBEVENT_GADGETOPEN,self,(BBInt64)node,0,0,0,0 );
-#else
-	PostGuiEvent( BBEVENT_GADGETOPEN,self,(int)node,0,0,0,0 );
-#endif
+	maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( BBEVENT_GADGETOPEN,NSPeerForNativeHandle(self),node,0,0,0 );
 }
 -(void)outlineViewItemDidCollapse:(NSNotification *)notification{
 	id		node;
 	node=[[notification userInfo] objectForKey:@"NSObject"];
+	// AppKit is still removing rows while posting this notification. Reconcile
+	// cached row views on the next main-loop turn, after that transaction ends.
+	[self performSelector:@selector(reconcileCollapsedNode:) withObject:node afterDelay:0.0];
 	[rootNode queueWidthUpdate];
-#ifdef __x86_64
-	PostGuiEvent( BBEVENT_GADGETCLOSE,self,(BBInt64)node,0,0,0,0 );
-#else
-	PostGuiEvent( BBEVENT_GADGETCLOSE,self,(int)node,0,0,0,0 );
-#endif
+	maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( BBEVENT_GADGETCLOSE,NSPeerForNativeHandle(self),node,0,0,0 );
 }
 -(void)outlineViewSelectionDidChange:(NSNotification *)notification{
 	id		node;
+	[self updateVisibleRows];
+	if (suppressSelectionEvents) return;
 	node=[self selectedNode];
-#ifdef __x86_64
-	PostGuiEvent( BBEVENT_GADGETSELECT,self,(BBInt64)node,0,0,0,0 );
-#else
-	PostGuiEvent( BBEVENT_GADGETSELECT,self,(int)node,0,0,0,0 );
-#endif
+	maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( BBEVENT_GADGETSELECT,NSPeerForNativeHandle(self),node,0,0,0 );
 }
 -(BOOL)outlineView:(NSOutlineView *)outlineView shouldEditTableColumn:(NSTableColumn *)tableColumn item:(id)item{
-#ifdef __x86_64
-	PostGuiEvent( BBEVENT_GADGETACTION,self,(BBInt64)item,0,0,0,0 );
-#else
-	PostGuiEvent( BBEVENT_GADGETACTION,self,(int)item,0,0,0,0 );
-#endif
 	return NO;
+}
+-(BOOL)performDoubleActionAtIndex:(NSInteger)index{
+	if (![outline isEnabled] || index<0 || index>=[outline numberOfRows]) return NO;
+	id item=[outline itemAtRow:index];
+	maxgui_cocoamaxgui_cocoagui_PostCocoaTreeEvent( BBEVENT_GADGETACTION,NSPeerForNativeHandle(self),item,0,0,0 );
+	return YES;
+}
+-(void)doubleClick:(id)sender{
+	[self performDoubleActionAtIndex:[outline clickedRow]];
+}
+-(BOOL)performUserSelectionAtIndex:(NSInteger)index{
+	if (![outline isEnabled] || index<0 || index>=[outline numberOfRows]) return NO;
+	[outline selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:NO];
+	return YES;
+}
+-(BOOL)performUserExpansionAtIndex:(NSInteger)index expand:(BOOL)expand{
+	if (![outline isEnabled] || index<0 || index>=[outline numberOfRows]) return NO;
+	id item=[outline itemAtRow:index];
+	if (![item canExpand]) return NO;
+	if (expand) [outline expandItem:item]; else [outline collapseItem:item];
+	return YES;
+}
+-(BOOL)isItemExpandedAtIndex:(NSInteger)index{
+	if (index<0 || index>=[outline numberOfRows]) return NO;
+	return [outline isItemExpanded:[outline itemAtRow:index]];
 }
 -(void)setColor:(NSColor*)color{
 	[outline setBackgroundColor:color];
 }
--(void)setTextColor:(NSColor*)color{
-	if (textstyle) {[textstyle release];textstyle=nil;}
-	if (color){
-		textstyle=[NSMutableDictionary dictionaryWithObjectsAndKeys:color,NSForegroundColorAttributeName,nil];
-		[textstyle retain];	
-	}
+-(void)setExplicitColor:(NSColor*)color appearance:(NSAppearance*)appearance{
+	[self setAppearance:appearance];
+	[outline setAppearance:nil];
+	[self setColor:color];
+	[self updateVisibleRows];
+	[outline setNeedsDisplay:YES];
 }
-- (void)setFont:(NSFont*)font{
-	if (font) {
-		NSLayoutManager* layoutManager = [[[NSLayoutManager alloc] init] autorelease];
-		int i;
-		NSArray *columnsArray = [outline tableColumns];
-		for (i= 0; i < [columnsArray count]; i++) {
-			[[[columnsArray objectAtIndex:i] dataCell] setFont:font];
+-(void)removeColor{
+	[self setAppearance:nil];
+	[outline setAppearance:nil];
+	[self setColor:[NSColor controlBackgroundColor]];
+	[self updateVisibleRows];
+	[outline setNeedsDisplay:YES];
+}
+-(void)setTextColor:(NSColor*)color{
+	if (textColor==color) return;
+	[textColor release];
+	textColor=[color retain];
+	[self updateVisibleRows];
+}
+
+- (void)setFont:(NSFont*)newFont{
+	if (newFont) {
+		if (font!=newFont){
+			[newFont retain];
+			[font release];
+			font=newFont;
 		}
-		[outline setRowHeight: [layoutManager defaultLineHeightForFont:font]+3];
-		
-		[cell setFont:font];
+		NSLayoutManager* layoutManager = [[[NSLayoutManager alloc] init] autorelease];
+		[outline setRowHeight:[layoutManager defaultLineHeightForFont:newFont]+3];
+		[self updateVisibleRows];
 		[rootNode queueWidthUpdate];
 	}
 }
-- (void)outlineView:(NSOutlineView *)outlineView willDisplayCell:(id)dcell forTableColumn:(NSTableColumn *)tableColumn item:(id)node{
-	if (textstyle){
-		[textstyle setValue:[cell font] forKey:NSFontAttributeName];
-		NSAttributedString *atext=[[[NSAttributedString alloc] initWithString:[node value] attributes:textstyle] autorelease];
-		[dcell setAttributedStringValue:atext];
-	}
-	else{
-		[dcell setStringValue:[node value]];
-	}
-	[dcell setImage:[node icon]];
-}
 -(void)setEnabled:(BOOL)e{
 	[outline setEnabled:e];
+	[self updateVisibleRows];
 }
 -(BOOL)isEnabled{
 	return [outline isEnabled];
 }
 @end
 
+int NSMaxGUITreeUsesViewBasedRows(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[TreeView class]]) return 0;
+	NSOutlineView *outline=((TreeView*)handle)->outline;
+	if ([outline numberOfRows]<1) return 0;
+	NSView *rowView=[outline viewAtColumn:0 row:0 makeIfNecessary:YES];
+	[rowView layoutSubtreeIfNeeded];
+	return [rowView isKindOfClass:[MaxGUIItemCellView class]] ? 1 : 0;
+}
+
+int NSMaxGUITreeAppearance(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[TreeView class]]) return -2;
+	NSAppearance *appearance=[(TreeView*)handle appearance];
+	if (!appearance) return -1;
+	NSString *match=[appearance bestMatchFromAppearancesWithNames:[NSArray arrayWithObjects:NSAppearanceNameAqua,NSAppearanceNameDarkAqua,nil]];
+	if ([match isEqualToString:NSAppearanceNameAqua]) return 0;
+	if ([match isEqualToString:NSAppearanceNameDarkAqua]) return 1;
+	return -2;
+}
+
+int NSMaxGUITreeEffectiveAppearance(void *handle){
+	if (!handle || ![(id)handle isKindOfClass:[TreeView class]]) return -2;
+	NSOutlineView *outline=((TreeView*)handle)->outline;
+	NSAppearance *appearance=[outline effectiveAppearance];
+	NSString *match=[appearance bestMatchFromAppearancesWithNames:[NSArray arrayWithObjects:NSAppearanceNameAqua,NSAppearanceNameDarkAqua,nil]];
+	if ([match isEqualToString:NSAppearanceNameAqua]) return 0;
+	if ([match isEqualToString:NSAppearanceNameDarkAqua]) return 1;
+	return -2;
+}
+
 // NodeItem
 
 @implementation NodeItem
--(void)dealloc{}
+-(void)dealloc{
+	[NSObject cancelPreviousPerformRequestsWithTarget:self];
+	[title release];
+	[icon release];
+	[kids release];
+	[super dealloc];
+}
 -(id)initWithTitle:(NSString*)text{
-	owner=nil;
-	parent=nil;
-	title=text;
-	icon=nil;
-	[title retain];
-	kids=[[NSMutableArray alloc] initWithCapacity:10];
-	[kids retain];
+	self=[super init];
+	if (self){
+		owner=nil;
+		parent=nil;
+		title=[text retain];
+		icon=nil;
+		kids=[[NSMutableArray alloc] initWithCapacity:10];
+	}
 	return self;
 }
 -(void)updateWidth{
 	int 		i;
-	float       cellWidth;
-	float       indentationWidth;
-	
-	NSCell*	dcell;
-	NSArray*	columnsArray;
+	CGFloat cellWidth;
+	CGFloat indentationWidth;
 	
 	if(owner==nil) return;
 	
@@ -1424,10 +2095,9 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	NSTableColumn*	tableColumn = owner->column;
 	
 	if(tableColumn!=nil){
-		dcell = [tableColumn dataCell];
-		[dcell setStringValue:title];
-		[dcell setImage:icon];
-		cellWidth = ((NSSize)[dcell cellSize]).width;
+		NSDictionary *attributes=[NSDictionary dictionaryWithObject:owner->font forKey:NSFontAttributeName];
+		cellWidth=[title sizeWithAttributes:attributes].width+8.0;
+		if (icon) cellWidth+=20.0;
 		indentationWidth = [outline levelForItem: self];
 		if(isnan(indentationWidth)) indentationWidth = 0; else indentationWidth=([outline indentationPerLevel]*(indentationWidth+1));
 		if((owner->rootNode == self) || [outline isItemExpanded:self])
@@ -1464,8 +2134,13 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	if (owner) [owner refresh];
 }
 -(void)remove{
-	if( parent ) [[parent kids] removeObject:self];
-	if (owner) [owner refresh];
+	TreeView *tree=owner;
+	[self retain];
+	if( parent ) [[parent kids] removeObjectIdenticalTo:self];
+	parent=nil;
+	owner=nil;
+	if (tree) [tree refresh];
+	[self release];
 }
 -(BOOL)canExpand{
 	return [kids count]>0;
@@ -1476,18 +2151,20 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(NSString *)value{return title;}
 -(NSImage *)icon{return icon;}
 -(void)setTitle:(NSString*)text{
+	if (title==text) return;
+	[text retain];
 	[title release];
 	title=text;
-	[title retain];
 	if (owner){
 		[owner->outline reloadItem:self];
 		[owner->rootNode queueWidthUpdate];
 	}
 }
 -(void)setIcon:(NSImage*)image{
-	if (icon) [icon release];
+	if (icon==image) return;
+	[image retain];
+	[icon release];
 	icon=image;
-	if (icon) [icon retain];
 	if (owner){
 		[owner->outline reloadItem:self];
 		[(icon ? self : owner->rootNode) queueWidthUpdate];
@@ -1526,7 +2203,6 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	[self setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
 	[[self textContainer] setContainerSize:NSMakeSize(FLT_MAX,FLT_MAX)];
 	[[self textContainer] setWidthTracksTextView:NO];	
-	[self setDelegate:self];
 	[self setUsesRuler:NO];
 
 	[scroll setDocumentView:self];
@@ -1536,10 +2212,11 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	
 	styles=[NSMutableDictionary dictionaryWithObject:style forKey:NSParagraphStyleAttributeName];
 	[styles retain];
-	storage=[self textStorage];
+	storage=[[self textStorage] retain];
 	[storage setDelegate:self];
 	
 	lockedNest=0;
+	programmaticChangeNest=0;
 	
 	[self setTabs: 4];
 	if ([self respondsToSelector: @selector(setDefaultParagraphStyle)])
@@ -1563,9 +2240,12 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 #endif
 #endif
 
+	[self setDelegate:self];
 	return self;
 }
 -(void)free{
+	[self setDelegate:nil];
+	[storage setDelegate:nil];
 	[scroll setDocumentView:nil];
 	[scroll release];
 	[style release];
@@ -1619,12 +2299,23 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 //	[storage addAttribute:NSParagraphStyleAttributeName value:style range:NSMakeRange(0,[storage length])];	
 }
 
+-(void)beginProgrammaticChange{
+	programmaticChangeNest++;
+}
+
+-(void)endProgrammaticChange{
+	if (programmaticChangeNest>0) programmaticChangeNest--;
+}
+
 -(void)setText:(NSString*)text{
 	NSAttributedString	*astring;
+	[self beginProgrammaticChange];
 	astring=[[NSAttributedString alloc] initWithString:text attributes:styles];
 	if (lockedNest) [storage endEditing];
 	[storage setAttributedString:astring];
 	if (lockedNest) [storage beginEditing]; else [self setSelectedRange:NSMakeRange(0,0)];
+	[astring release];
+	[self endProgrammaticChange];
 }
 -(void)addText:(NSString*)text{
 	NSAttributedString	*astring;
@@ -1632,6 +2323,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	if (lockedNest) [storage endEditing];
 	[storage appendAttributedString:astring];
 	if (lockedNest) [storage beginEditing];
+	[astring release];
 }
 -(void)setScrollFrame:(NSRect)rect{
 	[scroll setFrame:rect];
@@ -1648,7 +2340,10 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		[scroll setBackgroundColor:color];
 		[scroll setDrawsBackground:true];
 	}else{
-		[self setDrawsBackground:false];
+		NSColor *defaultColor=[NSColor textBackgroundColor];
+		[self setBackgroundColor:defaultColor];
+		[self setDrawsBackground:true];
+		[scroll setBackgroundColor:defaultColor];
 		[scroll setDrawsBackground:false];
 	}
 }
@@ -1658,11 +2353,8 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	[super setFont:font];	
 }
 -(NSMenu *)menuForEvent:(NSEvent *)event{
-	NSPoint	p;
-	int		x,y;
-	p=[event locationInWindow];	
-	x=(int)p.x;y=(int)p.y;
-	PostGuiEvent( BBEVENT_GADGETMENU,self,0,0,x,y,0 );
+	NSPoint point=MaxGUIEventPointInView(event,[self enclosingScrollView]);
+	PostGuiEvent( BBEVENT_GADGETMENU,self,0,0,(int)point.x,(int)point.y,0 );
 	return nil;
 }
 -(void)updateDragTypeRegistration{
@@ -1674,14 +2366,14 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 //	printf( "textDidBeginEditing:%p\n",_textEditor );fflush(stdout);
 }
 -(void)textDidChange:(NSNotification*)n{
-	PostGuiEvent( BBEVENT_GADGETACTION,self,0,0,0,0,0 );
+	if (!programmaticChangeNest) PostGuiEvent( BBEVENT_GADGETACTION,self,0,0,0,0,0 );
 }
 -(void)textDidEndEditing:(NSNotification*)n{
 //	printf( "textDidEndEditing:%p\n",_textEditor );fflush(stdout);
 	PostGuiEvent( BBEVENT_GADGETLOSTFOCUS,[n object],0,0,0,0,0 );
 }
 -(void)textViewDidChangeSelection:(NSNotification *)aNotification{
-	PostGuiEvent( BBEVENT_GADGETSELECT,self,0,0,0,0,0 );
+	if (!programmaticChangeNest) PostGuiEvent( BBEVENT_GADGETSELECT,self,0,0,0,0,0 );
 }
 -(void)textStorageDidProcessEditing:(NSNotification *)aNotification{
 
@@ -1712,11 +2404,15 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	return self;
 }
 -(void)setImage:(NSImage*)image{
-	_image=image;
-	if (_image) [_image setScalesWhenResized:YES];
+	if (_image==image) return;
+	[_image release];
+	_image=[image retain];
 }
 -(id)copyWithZone:(NSZone *)zone{
 	TabViewItem *copy=[[[self class] allocWithZone:zone] initWithIdentifier:[self identifier]];
+	[copy setLabel:[self label]];
+	[copy setImage:_image];
+	[copy setToolTip:[self toolTip]];
 	return copy;
 }
 -(NSImage*)image{
@@ -1725,7 +2421,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(NSSize)sizeOfLabel:(BOOL)shouldTruncateLabel{
 	NSSize	size;
 	NSSize	imageDimensions;
-	float		ratio;
+	CGFloat		ratio;
 	size=[super sizeOfLabel:shouldTruncateLabel];
 	
 	if (_image) {
@@ -1733,70 +2429,301 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		if (imageDimensions.height > size.height){
 			ratio = size.height/imageDimensions.height;
 			imageDimensions.width*=ratio;imageDimensions.height*=ratio;
-			[_image setSize: imageDimensions];
 		}
-		size.width += imageDimensions.height;
+		size.width += imageDimensions.width+4.0;
 	}
 	return size;
 }
 -(void)drawLabel:(BOOL)shouldTruncateLabel inRect:(NSRect)content{
 	NSSize	imageDimensions;
-	NSPoint	point;
+	NSRect imageRect;
 	if (_image){
 		imageDimensions = [_image size];
-		point = NSMakePoint(content.origin.x,content.origin.y+imageDimensions.height);
-		[_image compositeToPoint:point operation:NSCompositeSourceOver];
-		content.origin.x+=imageDimensions.width;content.size.width-=imageDimensions.width;		
+		if (imageDimensions.height > content.size.height){
+			CGFloat ratio=content.size.height/imageDimensions.height;
+			imageDimensions.width*=ratio;
+			imageDimensions.height*=ratio;
+		}
+		imageRect=NSMakeRect(content.origin.x,NSMidY(content)-imageDimensions.height/2.0,imageDimensions.width,imageDimensions.height);
+		[_image drawInRect:imageRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0 respectFlipped:YES hints:nil];
+		content.origin.x+=imageDimensions.width+4.0;
+		content.size.width-=imageDimensions.width+4.0;
 	}
 	[super drawLabel:shouldTruncateLabel inRect:content];
+}
+-(void)dealloc{
+	[_image release];
+	[super dealloc];
 }
 @end
 
 // TabView
 
+@implementation TabStripScrollView
+-(void)scrollWheel:(NSEvent *)event{
+	NSClipView *clip=[self contentView];
+	NSRect bounds=[clip bounds];
+	CGFloat delta=[event scrollingDeltaX];
+	if (fabs(delta)<fabs([event scrollingDeltaY])) delta=[event scrollingDeltaY];
+	if (![event hasPreciseScrollingDeltas]) delta*=12.0;
+	bounds.origin.x+=delta;
+	[clip scrollToPoint:[clip constrainBoundsRect:bounds].origin];
+	[self reflectScrolledClipView:clip];
+	id owner=[self superview];
+	if ([owner respondsToSelector:@selector(updateScrollButtons)]) [owner updateScrollButtons];
+}
+@end
+
+@implementation TabSegmentedControl
+-(void)scrollWheel:(NSEvent *)event{
+	[[self enclosingScrollView] scrollWheel:event];
+}
+-(NSMenu *)menuForEvent:(NSEvent *)event{
+	NSView *owner=[[self enclosingScrollView] superview];
+	if ([owner isKindOfClass:[TabView class]]) return [(TabView*)owner menuForEvent:event];
+	return [super menuForEvent:event];
+}
+@end
+
 @implementation TabView
 -(id)initWithFrame:(NSRect)rect{
-	rect.size.height+=8;
 	self=[super initWithFrame:rect];
-	[super setControlSize:NSSmallControlSize];
-	[super setFont:[NSFont labelFontOfSize:[NSFont smallSystemFontSize]]];	
-	client=[[FlippedView alloc] initWithFrame:[self contentRect]];
-	[client setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];	
-	[client retain];
-	user=1;	
-	[self setDelegate:self];
+	if (self){
+		[self setTabViewType:NSNoTabsNoBorder];
+		[self setDrawsBackground:NO];
+		client=[[FlippedView alloc] initWithFrame:[self contentRect]];
+		[client setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
+		segments=[[TabSegmentedControl alloc] initWithFrame:NSZeroRect];
+		[segments setSegmentStyle:NSSegmentStyleSeparated];
+		[segments setTrackingMode:NSSegmentSwitchTrackingSelectOne];
+		[segments setTarget:self];
+		[segments setAction:@selector(segmentSelected:)];
+		tabScroll=[[TabStripScrollView alloc] initWithFrame:NSZeroRect];
+		[tabScroll setBorderType:NSNoBorder];
+		[tabScroll setDrawsBackground:NO];
+		[tabScroll setHasHorizontalScroller:NO];
+		[tabScroll setHasVerticalScroller:NO];
+		[tabScroll setDocumentView:segments];
+		[self addSubview:tabScroll positioned:NSWindowAbove relativeTo:nil];
+		scrollLeft=[[NSButton alloc] initWithFrame:NSZeroRect];
+		[scrollLeft setTitle:@"\u2039"];
+		[scrollLeft setBezelStyle:NSBezelStyleTexturedRounded];
+		[scrollLeft setTarget:self];
+		[scrollLeft setAction:@selector(scrollTabsLeft:)];
+		[self addSubview:scrollLeft positioned:NSWindowAbove relativeTo:nil];
+		scrollRight=[[NSButton alloc] initWithFrame:NSZeroRect];
+		[scrollRight setTitle:@"\u203a"];
+		[scrollRight setBezelStyle:NSBezelStyleTexturedRounded];
+		[scrollRight setTarget:self];
+		[scrollRight setAction:@selector(scrollTabsRight:)];
+		[self addSubview:scrollRight positioned:NSWindowAbove relativeTo:nil];
+		user=1;
+		[self setDelegate:self];
+		[self synchronizeSegments];
+	}
 	return self;
 }
 -(id)clientView{
 	return client;
 }
+-(NSRect)contentRect{
+	NSRect bounds=[self bounds];
+	if ([self isFlipped]) bounds.origin.y+=28.0;
+	bounds.size.height=MAX(0.0,bounds.size.height-28.0);
+	return bounds;
+}
+-(CGFloat)naturalSegmentWidth{
+	CGFloat width=0.0;
+	for (NSInteger index=0;index<[segments segmentCount];index++) width+=[segments widthForSegment:index];
+	return width;
+}
+-(NSRect)rectForSegment:(NSInteger)wanted{
+	CGFloat x=0.0;
+	for (NSInteger index=0;index<wanted;index++) x+=[segments widthForSegment:index];
+	return NSMakeRect(x,0.0,[segments widthForSegment:wanted],[segments bounds].size.height);
+}
+-(void)layout{
+	[super layout];
+	NSRect bounds=[self bounds];
+	CGFloat barHeight=26.0;
+	CGFloat buttonWidth=22.0;
+	CGFloat naturalWidth=[self naturalSegmentWidth];
+	BOOL overflow=naturalWidth>bounds.size.width;
+	CGFloat scrollX=overflow ? buttonWidth : 0.0;
+	CGFloat scrollWidth=MAX(0.0,bounds.size.width-(overflow ? buttonWidth*2.0 : 0.0));
+	CGFloat stripY=[self isFlipped] ? 1.0 : MAX(0.0,bounds.size.height-barHeight-1.0);
+	[scrollLeft setHidden:!overflow];
+	[scrollRight setHidden:!overflow];
+	[scrollLeft setFrame:NSMakeRect(0.0,stripY,buttonWidth,barHeight)];
+	[scrollRight setFrame:NSMakeRect(MAX(0.0,bounds.size.width-buttonWidth),stripY,buttonWidth,barHeight)];
+	[tabScroll setFrame:NSMakeRect(scrollX,stripY,scrollWidth,barHeight)];
+	[segments setFrame:NSMakeRect(0.0,0.0,MAX(naturalWidth+8.0,scrollWidth),barHeight)];
+	[client setFrame:[self contentRect]];
+	[self updateScrollButtons];
+}
+-(void)synchronizeSegments{
+	NSInteger count=[self numberOfTabViewItems];
+	NSInteger selected=[self indexOfTabViewItem:[self selectedTabViewItem]];
+	[segments setSegmentCount:count];
+	NSFont *font=[segments font] ? [segments font] : [NSFont systemFontOfSize:[NSFont systemFontSize]];
+	NSDictionary *attributes=[NSDictionary dictionaryWithObject:font forKey:NSFontAttributeName];
+	for (NSInteger index=0;index<count;index++){
+		TabViewItem *item=(TabViewItem*)[self tabViewItemAtIndex:index];
+		NSString *label=[item label] ? [item label] : @"";
+		CGFloat width=ceil([label sizeWithAttributes:attributes].width)+28.0;
+		if ([item image]) width+=20.0;
+		width=MIN(220.0,MAX(64.0,width));
+		[segments setLabel:label forSegment:index];
+		[segments setImage:[item image] forSegment:index];
+		[segments setImageScaling:NSImageScaleProportionallyDown forSegment:index];
+		[segments setToolTip:[item toolTip] forSegment:index];
+		[segments setWidth:width forSegment:index];
+	}
+	[segments setSelectedSegment:selected==NSNotFound ? -1 : selected];
+	[self setNeedsLayout:YES];
+	[self layoutSubtreeIfNeeded];
+	[self revealSelectedSegment];
+}
+-(void)revealSelectedSegment{
+	NSInteger selected=[segments selectedSegment];
+	if (selected<0 || selected>=[segments segmentCount]) return;
+	NSClipView *clip=[tabScroll contentView];
+	NSRect visible=[clip bounds];
+	NSRect wanted=NSInsetRect([self rectForSegment:selected],-4.0,0.0);
+	if (NSMinX(wanted)<NSMinX(visible)) visible.origin.x=NSMinX(wanted);
+	else if (NSMaxX(wanted)>NSMaxX(visible)) visible.origin.x=NSMaxX(wanted)-visible.size.width;
+	[clip scrollToPoint:[clip constrainBoundsRect:visible].origin];
+	[tabScroll reflectScrolledClipView:clip];
+	[self updateScrollButtons];
+}
+-(void)updateScrollButtons{
+	NSClipView *clip=[tabScroll contentView];
+	CGFloat origin=[clip bounds].origin.x;
+	CGFloat maximum=MAX(0.0,[segments frame].size.width-[clip bounds].size.width);
+	BOOL enabled=[self isEnabled];
+	[scrollLeft setEnabled:enabled && origin>0.5];
+	[scrollRight setEnabled:enabled && origin<maximum-0.5];
+}
+-(void)scrollBy:(CGFloat)distance{
+	NSClipView *clip=[tabScroll contentView];
+	NSRect bounds=[clip bounds];
+	bounds.origin.x+=distance;
+	[clip scrollToPoint:[clip constrainBoundsRect:bounds].origin];
+	[tabScroll reflectScrolledClipView:clip];
+	[self updateScrollButtons];
+}
+-(void)scrollTabsLeft:(id)sender{
+	[self scrollBy:-MAX(80.0,[tabScroll bounds].size.width*0.7)];
+}
+-(void)scrollTabsRight:(id)sender{
+	[self scrollBy:MAX(80.0,[tabScroll bounds].size.width*0.7)];
+}
+-(void)segmentSelected:(id)sender{
+	if (![self isEnabled]) return;
+	NSInteger index=[segments selectedSegment];
+	if (index>=0 && index<[self numberOfTabViewItems]) [super selectTabViewItemAtIndex:index];
+}
+-(void)insertTabViewItem:(NSTabViewItem *)tabViewItem atIndex:(NSInteger)index{
+	[super insertTabViewItem:tabViewItem atIndex:index];
+	[self synchronizeSegments];
+}
+-(void)removeTabViewItem:(NSTabViewItem *)tabViewItem{
+	[super removeTabViewItem:tabViewItem];
+	[self synchronizeSegments];
+}
+-(void)removeAllItemsForFree{
+	[self setDelegate:nil];
+	while ([self numberOfTabViewItems]) [super removeTabViewItem:[self tabViewItemAtIndex:0]];
+	[segments setSegmentCount:0];
+}
+-(void)setEnabled:(BOOL)enabled{
+	[segments setEnabled:enabled];
+	[self updateScrollButtons];
+}
+-(BOOL)isEnabled{
+	return [segments isEnabled];
+}
 -(void)selectTabViewItemAtIndex:(int)index{
 	user=0;
 	[super selectTabViewItemAtIndex:index];
 	user=1;
-} 
+	[segments setSelectedSegment:index];
+	[self revealSelectedSegment];
+}
+-(BOOL)performUserSelectionAtIndex:(NSInteger)index{
+	if (![self isEnabled] || index<0 || index>=[self numberOfTabViewItems]) return NO;
+	[segments setSelectedSegment:index];
+	[self segmentSelected:segments];
+	[self revealSelectedSegment];
+	return YES;
+}
 -(void)setFrame:(NSRect)rect{
-	rect.size.height+=8;
 	[super setFrame:rect];
+	[self setNeedsLayout:YES];
 }
 -(BOOL)tabView:(NSTabView *)tabView shouldSelectTabViewItem:(NSTabViewItem *)tabViewItem{
 	int		index;
 	[tabViewItem setView:client];
 	[client setFrame:[self contentRect]];
-	if (user){
+	if (user && [self selectedTabViewItem]!=tabViewItem){
 		index=[self indexOfTabViewItem:tabViewItem];
 		PostGuiEvent( BBEVENT_GADGETACTION,self,index,0,0,0,0);
 	}
 	return YES;
 }
+-(void)tabView:(NSTabView *)tabView didSelectTabViewItem:(NSTabViewItem *)tabViewItem{
+	NSInteger index=[self indexOfTabViewItem:tabViewItem];
+	[segments setSelectedSegment:index==NSNotFound ? -1 : index];
+	[self revealSelectedSegment];
+}
+-(NSTabViewItem *)tabViewItemAtPoint:(NSPoint)point{
+	if (!NSPointInRect(point,[tabScroll frame])) return nil;
+	NSPoint segmentPoint=[segments convertPoint:point fromView:self];
+	if (!NSPointInRect(segmentPoint,[segments visibleRect])) return nil;
+	for (NSInteger index=0;index<[segments segmentCount];index++){
+		if (NSPointInRect(segmentPoint,[self rectForSegment:index])) return [self tabViewItemAtIndex:index];
+	}
+	return nil;
+}
+-(void)setFont:(NSFont *)font{
+	[super setFont:font];
+	[segments setFont:font];
+	[self synchronizeSegments];
+}
+-(int)overflowPresentation{
+	[self layoutSubtreeIfNeeded];
+	int result=[segments isKindOfClass:[NSSegmentedControl class]] ? 1 : 0;
+	if (![scrollLeft isHidden] && ![scrollRight isHidden]) result|=2;
+	if ([segments frame].size.width>[tabScroll contentView].bounds.size.width) result|=4;
+	NSInteger selected=[segments selectedSegment];
+	if (selected>=0){
+		NSRect visible=[[tabScroll contentView] bounds];
+		NSRect selectedRect=[self rectForSegment:selected];
+		CGFloat visibleWidth=NSIntersectionRect(visible,selectedRect).size.width;
+		if (visibleWidth>=MIN(visible.size.width,selectedRect.size.width)-8.0) result|=8;
+	}
+	BOOL ordered=YES;
+	CGFloat edge=-CGFLOAT_MAX;
+	for (NSInteger index=0;index<[segments segmentCount];index++){
+		NSRect rect=[self rectForSegment:index];
+		if (rect.size.width<=0.0 || NSMinX(rect)<edge-0.5){ ordered=NO; break; }
+		edge=NSMaxX(rect);
+	}
+	if (ordered) result|=16;
+	NSRect bounds=[self bounds];
+	NSRect strip=[tabScroll frame];
+	BOOL atTop=[self isFlipped] ? NSMinY(strip)<=NSMinY(bounds)+2.0 : NSMaxY(strip)>=NSMaxY(bounds)-2.0;
+	if (atTop) result|=32;
+	return result;
+}
 -(void)dealloc{
-	NSArray			*items;
-	int				i,n;
-	
-	items=[self tabViewItems];
-	n=[items count];
-	for (i=0;i<n;i++) [self removeTabViewItem:[items objectAtIndex:0]];
+	[self removeAllItemsForFree];
 
+	[tabScroll setDocumentView:nil];
+	[segments release];
+	[tabScroll release];
+	[scrollLeft release];
+	[scrollRight release];
 	[client release];
 	[super dealloc];
 }
@@ -1805,10 +2732,139 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	NSTabViewItem*	tabItem;
 	tabItem = [self tabViewItemAtPoint:[self convertPoint:[event locationInWindow] fromView:nil]];
 	if (tabItem) index = [self indexOfTabViewItem:tabItem]; else index = -1;
-	PostGuiEvent( BBEVENT_GADGETMENU,self,index,0,0,0,0);
-	return [super menuForEvent:event];
+	NSPoint point=MaxGUIEventPointInView(event,self);
+	PostGuiEvent( BBEVENT_GADGETMENU,self,index,0,(int)point.x,(int)point.y,0);
+	return nil;
 }
 @end
+
+int NSMaxGUIContextMenuEvent(void *handle,int gadgetClass,int x,int y){
+	NSView *gadgetView=nil;
+	NSView *eventView=nil;
+	switch (gadgetClass){
+		case GADGET_LISTBOX:
+			gadgetView=(ListView*)handle;
+			eventView=[(ListView*)handle table];
+			break;
+		case GADGET_TREEVIEW:
+			gadgetView=(TreeView*)handle;
+			eventView=((TreeView*)handle)->outline;
+			break;
+		case GADGET_TEXTAREA:
+			eventView=(TextView*)handle;
+			gadgetView=[(TextView*)handle getScroll];
+			break;
+		case GADGET_TABBER:
+			gadgetView=(TabView*)handle;
+			eventView=gadgetView;
+			break;
+		default:
+			return 0;
+	}
+	if (!gadgetView || !eventView || ![gadgetView window]) return 0;
+	[gadgetView layoutSubtreeIfNeeded];
+	[eventView layoutSubtreeIfNeeded];
+	NSRect bounds=[gadgetView bounds];
+	NSPoint gadgetPoint=NSMakePoint(NSMinX(bounds)+x,[gadgetView isFlipped] ? NSMinY(bounds)+y : NSMaxY(bounds)-y);
+	NSPoint windowPoint=[gadgetView convertPoint:gadgetPoint toView:nil];
+	NSEvent *event=[NSEvent mouseEventWithType:NSEventTypeRightMouseUp
+		location:windowPoint modifierFlags:0 timestamp:0
+		windowNumber:[[gadgetView window] windowNumber] context:nil
+		eventNumber:0 clickCount:1 pressure:0];
+	[eventView menuForEvent:event];
+	return 1;
+}
+
+int NSMaxGUIContextMenuItemEvent(void *handle,int gadgetClass,int index){
+	NSView *gadgetView=nil;
+	NSView *eventView=nil;
+	NSPoint eventPoint=NSZeroPoint;
+	if (gadgetClass==GADGET_LISTBOX){
+		ListView *list=(ListView*)handle;
+		NSTableView *table=(NSTableView*)[list table];
+		gadgetView=list;
+		eventView=table;
+		if (index<0 || index>=[table numberOfRows]) return -1;
+		eventPoint=NSMakePoint(12,NSMidY([table rectOfRow:index]));
+	}
+	else if (gadgetClass==GADGET_TREEVIEW){
+		TreeView *tree=(TreeView*)handle;
+		gadgetView=tree;
+		eventView=tree->outline;
+		if (index<0 || index>=[tree->outline numberOfRows]) return -1;
+		eventPoint=NSMakePoint(20,NSMidY([tree->outline rectOfRow:index]));
+	}
+	else if (gadgetClass==GADGET_TABBER){
+		TabView *tab=(TabView*)handle;
+		gadgetView=tab;
+		eventView=tab;
+		if (index<0 || index>=[tab numberOfTabViewItems]) return -1;
+		NSTabViewItem *wanted=[tab tabViewItemAtIndex:index];
+		NSRect bounds=[tab bounds];
+		for (NSInteger y=(NSInteger)NSMinY(bounds); y<(NSInteger)NSMaxY(bounds); y++){
+			for (NSInteger x=(NSInteger)NSMinX(bounds); x<(NSInteger)NSMaxX(bounds); x++){
+				NSPoint candidate=NSMakePoint(x,y);
+				if ([tab tabViewItemAtPoint:candidate]==wanted){
+					eventPoint=candidate;
+					y=(NSInteger)NSMaxY(bounds);
+					break;
+				}
+			}
+		}
+		if (NSEqualPoints(eventPoint,NSZeroPoint)) return -1;
+	}
+	else return -1;
+	[gadgetView layoutSubtreeIfNeeded];
+	[eventView layoutSubtreeIfNeeded];
+	NSPoint windowPoint=[eventView convertPoint:eventPoint toView:nil];
+	NSEvent *event=[NSEvent mouseEventWithType:NSEventTypeRightMouseUp
+		location:windowPoint modifierFlags:0 timestamp:0
+		windowNumber:[[gadgetView window] windowNumber] context:nil
+		eventNumber:0 clickCount:1 pressure:0];
+	NSPoint gadgetPoint=MaxGUIEventPointInView(event,gadgetView);
+	[eventView menuForEvent:event];
+	return (((int)gadgetPoint.y & 0xffff)<<16)|((int)gadgetPoint.x & 0xffff);
+}
+
+int NSMaxGUIContextMenuBlankEvent(void *handle,int gadgetClass){
+	NSView *gadgetView=nil;
+	NSView *eventView=nil;
+	if (gadgetClass==GADGET_LISTBOX){
+		gadgetView=(ListView*)handle;
+		eventView=[(ListView*)handle table];
+	}
+	else if (gadgetClass==GADGET_TREEVIEW){
+		gadgetView=(TreeView*)handle;
+		eventView=((TreeView*)handle)->outline;
+	}
+	else if (gadgetClass==GADGET_TABBER){
+		gadgetView=(TabView*)handle;
+		eventView=gadgetView;
+	}
+	else return -1;
+	[gadgetView layoutSubtreeIfNeeded];
+	[eventView layoutSubtreeIfNeeded];
+	NSRect bounds=[gadgetView bounds];
+	for (int y=5; y<(int)NSHeight(bounds)-5; y++){
+		for (int x=5; x<(int)NSWidth(bounds)-5; x++){
+			NSPoint gadgetPoint=NSMakePoint(NSMinX(bounds)+x,[gadgetView isFlipped] ? NSMinY(bounds)+y : NSMaxY(bounds)-y);
+			NSPoint windowPoint=[gadgetView convertPoint:gadgetPoint toView:nil];
+			NSPoint eventPoint=[eventView convertPoint:windowPoint fromView:nil];
+			BOOL blank=NO;
+			if (gadgetClass==GADGET_TABBER) blank=[(TabView*)eventView tabViewItemAtPoint:eventPoint]==nil;
+			else{
+				NSTableView *table=(NSTableView*)eventView;
+				NSInteger row=[table rowAtPoint:eventPoint];
+				blank=row<0 || row>=[table numberOfRows] || !NSPointInRect(eventPoint,[table rectOfRow:row]);
+			}
+			if (blank){
+				if (!NSMaxGUIContextMenuEvent(handle,gadgetClass,x,y)) return -1;
+				return ((y & 0xffff)<<16)|(x & 0xffff);
+			}
+		}
+	}
+	return -1;
+}
 
 // WindowView
 
@@ -1822,21 +2878,21 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	}
 	return r;
 }
--(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withGadget:(nsgadget*)_gadget{
+-(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withStyle:(int)style{
 //withStatus:(BOOL)status{
-	id		client;
+	NSView		*client;
 	int		i;
-	NSText	*l;
+	NSTextField	*l;
 	NSBox	*box;
 	dragging = nil;
 	self=[super initWithContentRect:rect styleMask:mask backing:backing defer:flag];
-	gadget=_gadget;
+	gadgetStyle=style;
 	view=[[FlippedView alloc] init];
 	enabled=true;
 	[self setContentView:view];
 	[self setAcceptsMouseMovedEvents:YES];
 	[self disableCursorRects];	//Fixes NSSetPointer not sticking.
-	if (gadget->style&WINDOW_STATUS){
+	if (gadgetStyle&WINDOW_STATUS){
 		rect.origin.x=rect.origin.y=0;
 		rect.size.height-=STATUSBARHEIGHT;
 		client=[[FlippedView alloc] initWithFrame:rect];
@@ -1845,17 +2901,22 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 // label for window status
 		rect.origin.y=rect.size.height+3;
 		rect.size.height=STATUSBARHEIGHT-4;		
-		rect.size.width-=[NSScroller scrollerWidth];
+		rect.size.width-=MaxGUIScrollerWidth();
 		for (i=0;i<3;i++){
-			l=[[NSText alloc] initWithFrame:rect];
+			l=[[NSTextField alloc] initWithFrame:rect];
+			[l setBezeled:NO];
+			[l setBordered:NO];
 			[l setDrawsBackground:NO];
 			[l setEditable:NO];
 			[l setSelectable:NO];
+			[l setLineBreakMode:NSLineBreakByTruncatingTail];
+			[l setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];
+			[l setTextColor:[NSColor secondaryLabelColor]];
 			[l setAutoresizingMask:NSViewWidthSizable|NSViewMinYMargin];
 			switch (i){
-				case 0:[l setAlignment:NSLeftTextAlignment];break;
-				case 1:[l setAlignment:NSCenterTextAlignment];break;
-				case 2:[l setAlignment:NSRightTextAlignment];break;
+				case 0:[l setAlignment:NSTextAlignmentLeft];break;
+				case 1:[l setAlignment:NSTextAlignmentCenter];break;
+				case 2:[l setAlignment:NSTextAlignmentRight];break;
 			}
 			if (view) [view addSubview:l];
 			label[i]=l;
@@ -1863,7 +2924,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		
 		rect.origin.y-=3;
 		rect.size.height=2;
-		rect.size.width+=[NSScroller scrollerWidth];
+		rect.size.width+=MaxGUIScrollerWidth();
 		
 		box=[[NSBox alloc] initWithFrame:rect];
 		[box setBoxType:NSBoxSeparator];
@@ -1880,7 +2941,10 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	return view;
 }
 -(void)setStatus:(NSString*)text align:(int)pos{
-	if (label[pos]) [label[pos] setString:text];
+	if (label[pos]) [label[pos] setStringValue:text];
+}
+-(id)statusLabelAtIndex:(NSInteger)index{
+	return index>=0 && index<3 ? label[index] : nil;
 }
 -(void)sendEvent:(NSEvent*)event{
 	
@@ -1891,28 +2955,29 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	// Handling of Generic Key/Mouse Events
 	
 	switch( [event type] ){
-	case NSMouseEntered:
+	case NSEventTypeMouseEntered:
 		[self disableCursorRects];
-	case NSLeftMouseDown:
-	case NSRightMouseDown:
-	case NSOtherMouseDown:
-		if( [event type] != NSMouseEntered ){
+	case NSEventTypeLeftMouseDown:
+	case NSEventTypeRightMouseDown:
+	case NSEventTypeOtherMouseDown:
+		if( [event type] != NSEventTypeMouseEntered ){
 			dragging = [[self contentView] hitTest:[event locationInWindow]];
 			[self makeFirstResponder:dragging];
 		}
-	case NSMouseMoved:
-	case NSMouseExited:
-	case NSScrollWheel:
+	case NSEventTypeMouseMoved:
+	case NSEventTypeMouseExited:
+	case NSEventTypeScrollWheel:
 	{
 		NSView *hitView = [[self contentView] hitTest:[event locationInWindow]];
 		if (hitView) EmitMouseEvent( event, hitView );
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSLeftMouseUp:
-	case NSRightMouseUp:
-	case NSOtherMouseUp:
+	case NSEventTypeLeftMouseUp:
+	case NSEventTypeRightMouseUp:
+	case NSEventTypeOtherMouseUp:
 	{
+		MaxGUIPostDropForEvent(event);
 		//fire event for the dragged view
 		if (dragging) {
 			EmitMouseEvent( event, dragging );
@@ -1926,23 +2991,25 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSLeftMouseDragged:
-	case NSRightMouseDragged:
-	case NSOtherMouseDragged:
+	case NSEventTypeLeftMouseDragged:
+	case NSEventTypeRightMouseDragged:
+	case NSEventTypeOtherMouseDragged:
 	{
 		if( dragging == nil ) dragging = [[self contentView] hitTest:[event locationInWindow]];
 		if( dragging ) EmitMouseEvent( event, dragging );
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSKeyDown:
-	case NSKeyUp:
-	case NSFlagsChanged:
+	case NSEventTypeKeyDown:
+	case NSEventTypeKeyUp:
+	case NSEventTypeFlagsChanged:
 	{
 		NSResponder *handle=(NSResponder*)NSActiveGadget();
 		if( handle && EmitKeyEvent( event, handle )) return;
 		break;
 	}
+	default:
+		break;
 	}
 	
 	// End of Generic Key/Mouse Events
@@ -1950,8 +3017,8 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	// Gadget Filterkey Processing
 	
 	switch( [event type] ){
-	case NSKeyDown:
-		if( key=bbSystemTranslateKey( [event keyCode] ) ){
+	case NSEventTypeKeyDown:
+		if( (key=bbSystemTranslateKey( [event keyCode] )) ){
 			int mods=bbSystemTranslateMods( [event modifierFlags] );
 			BBObject *event=maxgui_maxgui_HotKeyEvent( key,mods );
 			if( event!=&bbNullObject ){
@@ -1964,13 +3031,15 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		if( source && !filterKeyDownEvent( event,source ) ) return;		
 		if(![self isEnabled]) return;
 		break;
-	case NSKeyUp:
+	case NSEventTypeKeyUp:
 		key=bbSystemTranslateKey([event keyCode]);
 		if( lastHotKey && (key==lastHotKey ) ){
 			lastHotKey=0;
 			return;
 		}
 		if(![self isEnabled]) return;
+		break;
+	default:
 		break;
 	}
 	lastHotKey=0;
@@ -1980,25 +3049,10 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	[super sendEvent:event];
 }
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender{
-//	printf("windowview got dragenter\n");fflush(stdout);
-	return YES;
+	return MaxGUIFileDragOperation(sender);
 }
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender{
-	NSPasteboard *pboard = [sender draggingPasteboard];
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
-		NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
-		int numberOfFiles = [files count];
-		// Perform operation using the list of files
-		// printf("windowview got drag\n");fflush(stdout);
-		int i;
-		for (i=0;i<numberOfFiles;i++)
-		{
-			BBString *name=bbStringFromNSString([files objectAtIndex:i]);
-			maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( BBEVENT_WINDOWACCEPT,self,0,0,0,0,(BBObject*)name );
-		}
-		
-	}
-	return YES;
+	return MaxGUIAcceptDroppedFiles(self,sender);
 }
 -(void)didResize{
 	NSRect rect=[self localRect];
@@ -2017,7 +3071,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	int style;
 
 	rect=[self frame];
-	style=gadget->style;
+	style=gadgetStyle;
 	if (style&WINDOW_CLIENTCOORDS){
 		rect=[self contentRectForFrameRect:rect];
 		if (style&WINDOW_STATUS) {
@@ -2049,7 +3103,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(void)dealloc{
 	int i;
 	id sview;
-	if (gadget->style&WINDOW_STATUS) {
+	if (gadgetStyle&WINDOW_STATUS) {
 		for (i = 0; i < 3; i++) {
 			if (label[i]) {
 				[label[i] removeFromSuperview];
@@ -2084,21 +3138,21 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	}
 	return r;
 }
--(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withGadget:(nsgadget*)_gadget{
+-(id)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)backing defer:(BOOL)flag withStyle:(int)style{
 //withStatus:(BOOL)status{
-	id		client;
+	NSView		*client;
 	int		i;
-	NSText	*l;
+	NSTextField	*l;
 	NSBox	*box;
 	dragging = nil;
 	self=[super initWithContentRect:rect styleMask:mask backing:backing defer:flag];
-	gadget=_gadget;
+	gadgetStyle=style;
 	view=[[FlippedView alloc] init];
 	enabled=true;
 	[self setContentView:view];
 	[self setAcceptsMouseMovedEvents:YES];
 	[self disableCursorRects];	//Fixes NSSetPointer not sticking.
-	if (gadget->style&WINDOW_STATUS){			//status){	//mask&NSTexturedBackgroundWindowMask)
+	if (gadgetStyle&WINDOW_STATUS){			//status){	//mask&NSTexturedBackgroundWindowMask)
 		rect.origin.x=rect.origin.y=0;
 		rect.size.height-=STATUSBARHEIGHT;
 		client=[[FlippedView alloc] initWithFrame:rect];
@@ -2107,17 +3161,22 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 // label for window status
 		rect.origin.y=rect.size.height+3;
 		rect.size.height=STATUSBARHEIGHT-4;		
-		rect.size.width-=[NSScroller scrollerWidth];
+		rect.size.width-=MaxGUIScrollerWidth();
 		for (i=0;i<3;i++){
-			l=[[NSText alloc] initWithFrame:rect];
+			l=[[NSTextField alloc] initWithFrame:rect];
+			[l setBezeled:NO];
+			[l setBordered:NO];
 			[l setDrawsBackground:NO];
 			[l setEditable:NO];
 			[l setSelectable:NO];
+			[l setLineBreakMode:NSLineBreakByTruncatingTail];
+			[l setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];
+			[l setTextColor:[NSColor secondaryLabelColor]];
 			[l setAutoresizingMask:NSViewWidthSizable|NSViewMinYMargin];
 			switch (i){
-				case 0:[l setAlignment:NSLeftTextAlignment];break;
-				case 1:[l setAlignment:NSCenterTextAlignment];break;
-				case 2:[l setAlignment:NSRightTextAlignment];break;
+				case 0:[l setAlignment:NSTextAlignmentLeft];break;
+				case 1:[l setAlignment:NSTextAlignmentCenter];break;
+				case 2:[l setAlignment:NSTextAlignmentRight];break;
 			}
 			if (view) [view addSubview:l];
 			label[i]=l;
@@ -2125,7 +3184,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		
 		rect.origin.y-=3;
 		rect.size.height=2;
-		rect.size.width+=[NSScroller scrollerWidth];
+		rect.size.width+=MaxGUIScrollerWidth();
 		
 		box=[[NSBox alloc] initWithFrame:rect];
 		[box setBoxType:NSBoxSeparator];
@@ -2143,7 +3202,10 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	return view;
 }
 -(void)setStatus:(NSString*)text align:(int)pos{
-	if (label[pos]) [label[pos] setString:text];
+	if (label[pos]) [label[pos] setStringValue:text];
+}
+-(id)statusLabelAtIndex:(NSInteger)index{
+	return index>=0 && index<3 ? label[index] : nil;
 }
 -(void)sendEvent:(NSEvent*)event{
 	
@@ -2154,30 +3216,31 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	// Handling of Generic Key/Mouse Events
 	
 	switch( [event type] ){
-	case NSMouseEntered:
+	case NSEventTypeMouseEntered:
 		[self disableCursorRects];
-	case NSLeftMouseDown:
-	case NSRightMouseDown:
-	case NSOtherMouseDown:
+	case NSEventTypeLeftMouseDown:
+	case NSEventTypeRightMouseDown:
+	case NSEventTypeOtherMouseDown:
 	{
-		if( [event type] != NSMouseEntered ){
+		if( [event type] != NSEventTypeMouseEntered ){
 			dragging = [[self contentView] hitTest:[event locationInWindow]];
 			[self makeFirstResponder:dragging];
 		}
 	}
-	case NSMouseMoved:
-	case NSMouseExited:
-	case NSScrollWheel:
+	case NSEventTypeMouseMoved:
+	case NSEventTypeMouseExited:
+	case NSEventTypeScrollWheel:
 	{
 		NSView *hitView = [[self contentView] hitTest:[event locationInWindow]];
 		if (hitView) EmitMouseEvent( event, hitView );
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSLeftMouseUp:
-	case NSRightMouseUp:
-	case NSOtherMouseUp:
+	case NSEventTypeLeftMouseUp:
+	case NSEventTypeRightMouseUp:
+	case NSEventTypeOtherMouseUp:
 	{
+		MaxGUIPostDropForEvent(event);
 		//fire event for the dragged view
 		if (dragging) {
 			EmitMouseEvent( event, dragging );
@@ -2191,23 +3254,25 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSLeftMouseDragged:
-	case NSRightMouseDragged:
-	case NSOtherMouseDragged:
+	case NSEventTypeLeftMouseDragged:
+	case NSEventTypeRightMouseDragged:
+	case NSEventTypeOtherMouseDragged:
 	{
 		if( dragging == nil ) dragging = [[self contentView] hitTest:[event locationInWindow]];
 		if( dragging ) EmitMouseEvent( event, dragging );
 		if(![self isEnabled]) return;
 		break;
 	}
-	case NSKeyDown:
-	case NSKeyUp:
-	case NSFlagsChanged:
+	case NSEventTypeKeyDown:
+	case NSEventTypeKeyUp:
+	case NSEventTypeFlagsChanged:
 	{
 		NSResponder *handle=(NSResponder*)NSActiveGadget();
 		if( handle && EmitKeyEvent( event, handle )) return;
 		break;
 	}
+	default:
+		break;
 	}
 	
 	// End of Generic Key/Mouse Events
@@ -2215,8 +3280,8 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	// Gadget Filterkey Processing
 	
 	switch( [event type] ){
-	case NSKeyDown:
-		if( key=bbSystemTranslateKey( [event keyCode] ) ){
+	case NSEventTypeKeyDown:
+		if( (key=bbSystemTranslateKey( [event keyCode] )) ){
 			int mods=bbSystemTranslateMods( [event modifierFlags] );
 			BBObject *event=maxgui_maxgui_HotKeyEvent( key,mods );
 			if( event!=&bbNullObject ){
@@ -2229,13 +3294,15 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 		if( source && !filterKeyDownEvent( event,source ) ) return;		
 		if(![self isEnabled]) return;
 		break;
-	case NSKeyUp:
+	case NSEventTypeKeyUp:
 		key=bbSystemTranslateKey([event keyCode]);
 		if( lastHotKey && (key==lastHotKey ) ){
 			lastHotKey=0;
 			return;
 		}
 		if(![self isEnabled]) return;
+		break;
+	default:
 		break;
 	}
 	lastHotKey=0;
@@ -2245,25 +3312,10 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	[super sendEvent:event];
 }
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender{
-//	printf("windowview got dragenter\n");fflush(stdout);
-	return YES;
+	return MaxGUIFileDragOperation(sender);
 }
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender{
-	NSPasteboard *pboard = [sender draggingPasteboard];
-	if ( [[pboard types] containsObject:NSFilenamesPboardType] ) {
-		NSArray *files = [pboard propertyListForType:NSFilenamesPboardType];
-		int numberOfFiles = [files count];
-		// Perform operation using the list of files
-		// printf("windowview got drag\n");fflush(stdout);
-		int i;
-		for (i=0;i<numberOfFiles;i++)
-		{
-			BBString *name=bbStringFromNSString([files objectAtIndex:i]);
-			maxgui_cocoamaxgui_cocoagui_PostCocoaGuiEvent( BBEVENT_WINDOWACCEPT,self,0,0,0,0,(BBObject*)name );
-		}
-		
-	}
-	return YES;
+	return MaxGUIAcceptDroppedFiles(self,sender);
 }
 -(void)didResize{
 	if (zooming) {
@@ -2285,7 +3337,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 	int style;
 
 	rect=[self frame];
-	style=gadget->style;
+	style=gadgetStyle;
 	if (style&WINDOW_CLIENTCOORDS){
 		rect=[self contentRectForFrameRect:rect];
 		if (style&WINDOW_STATUS) {
@@ -2317,7 +3369,7 @@ tableColumn:(NSTableColumn *)aTableColumn row:(int)row mouseLocation:(NSPoint)mo
 -(void)dealloc{
 	int i;
 	id sview;
-	if (gadget->style&WINDOW_STATUS) {
+	if (gadgetStyle&WINDOW_STATUS) {
 		for (i = 0; i < 3; i++) {
 			if (label[i]) {
 				[label[i] removeFromSuperview];
@@ -2349,6 +3401,9 @@ void NSBegin(){
 
 void NSEnd(){
 	[GlobalApp release];
+	[MaxGUITopMenuProxies release];
+	MaxGUITopMenuProxies=nil;
+	MaxGUIAppMenu=nil;
 }
 
 void* NSActiveGadget(){
@@ -2366,15 +3421,17 @@ void* NSActiveGadget(){
 	return responder;
 }
 
-void NSInitGadget(nsgadget *gadget){
+void NSPeerInitializeGadget(void *peer,BBString *textarg,int *x,int *y,int *w,int *h,void *groupPeer){
 	NSRect 				rect,vis;
 	NSString 			*text;
-	NSView				*view;
+	NSView				*view=nil;
+	id				nativeHandle=nil;
+	NSView				*clientView=nil;
 	NSWindow		*window;
 	NSButton			*button;
 	NSTextField			*textfield;
 	TextView			*textarea;
-	NSControl 		*combobox;
+	NSComboBox 		*combobox;
 	Toolbar			*toolbar;
 	TabView				*tabber;
 	TreeView			*treeview;
@@ -2392,35 +3449,39 @@ void NSInitGadget(nsgadget *gadget){
 	NSMenu				*menu;
 	NSMenuItem			*menuitem;
 	NodeItem			*node,*parent;
-	nsgadget				*group;
-	int 					style,flags;
+	int 					gadgetClass=NSPeerGadgetClass(peer);
+	int 					style=NSPeerGadgetStyle(peer);
+	int					groupClass=0;
+	id					groupHandle=nil;
+	int 					flags=0;
 	NSImage			*image;
 		
-	rect=NSMakeRect(gadget->x,gadget->y,gadget->w,gadget->h);
-	text=NSStringFromBBString(gadget->textarg);
-	style=gadget->style;flags=0;
-	group=gadget->group;
-	if (group==(nsgadget*)&bbNullObject) group=0;
-	if (group) view=gadget->group->view;
+	rect=NSMakeRect(*x,*y,*w,*h);
+	text=NSStringFromBBString(textarg);
+	if (groupPeer){
+		groupClass=NSPeerGadgetClass(groupPeer);
+		groupHandle=NSPeerNativeHandle(groupPeer);
+		view=(NSView*)NSPeerClientView(groupPeer);
+	}
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_DESKTOP:
 		rect=[[NSScreen deepestScreen] frame];
-		gadget->x=rect.origin.x;
-		gadget->y=rect.origin.y;
-		gadget->w=rect.size.width;
-		gadget->h=rect.size.height;
+		*x=rect.origin.x;
+		*y=rect.origin.y;
+		*w=rect.size.width;
+		*h=rect.size.height;
 		break;
 	case GADGET_WINDOW:
 		vis=[[NSScreen deepestScreen] visibleFrame];
 		rect.origin.x+=vis.origin.x;
 		rect.origin.y=vis.origin.y+vis.size.height-rect.origin.y-rect.size.height;
-		if (style&WINDOW_TITLEBAR) flags|=NSTitledWindowMask|NSClosableWindowMask;
+		if (style&WINDOW_TITLEBAR) flags|=NSWindowStyleMaskTitled|NSWindowStyleMaskClosable;
 		if (style&WINDOW_RESIZABLE){
-			flags|=NSResizableWindowMask;
-			if (!(group && (group->internalclass==GADGET_WINDOW))) flags |=NSMiniaturizableWindowMask;
+			flags|=NSWindowStyleMaskResizable;
+			if (!(groupPeer && groupClass==GADGET_WINDOW)) flags |=NSWindowStyleMaskMiniaturizable;
 		}
-		if (style&WINDOW_TOOL) flags|=NSUtilityWindowMask;
+		if (style&WINDOW_TOOL) flags|=NSWindowStyleMaskUtilityWindow;
 		[NSApp activateIgnoringOtherApps:YES];
 		if (!(style&WINDOW_CLIENTCOORDS)){
 			rect=[NSWindow contentRectForFrameRect:rect styleMask:flags];
@@ -2431,61 +3492,62 @@ void NSInitGadget(nsgadget *gadget){
 			}
 		}
 		if (!(style&WINDOW_TOOL)) {
-			window=[[WindowView alloc] initWithContentRect:rect styleMask:flags backing:NSBackingStoreBuffered defer:YES withGadget:gadget];
+			window=[[WindowView alloc] initWithContentRect:rect styleMask:flags backing:NSBackingStoreBuffered defer:YES withStyle:style];
 		} else {
-			window=[[ToolView alloc] initWithContentRect:rect styleMask:flags backing:NSBackingStoreBuffered defer:YES withGadget:gadget];
+			window=[[ToolView alloc] initWithContentRect:rect styleMask:flags backing:NSBackingStoreBuffered defer:YES withStyle:style];
 		}
-		[window setOpaque:NO];
-		[window setAlphaValue:.999f];	
+		[window setOpaque:YES];
+		[window setAlphaValue:1.0];
 		
 		if (style&WINDOW_HIDDEN) [window orderOut:window]; else [window makeKeyAndOrderFront:NSApp];
 		
-		if (group && (group->internalclass==GADGET_WINDOW)){
+		if (groupPeer && groupClass==GADGET_WINDOW){
 			NSWindow	*parent;
-			parent=(NSWindow*)group->handle;
+			parent=(NSWindow*)groupHandle;
 			if(!(style&WINDOW_HIDDEN)) [parent addChildWindow:window ordered:NSWindowAbove];
 			[window setParentWindow:parent];
 		}
 		
 		if (style&WINDOW_ACCEPTFILES)
-			[window registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]]; 
+			[window registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
 		
 		[window setTitle:text];	
 		[window setDelegate:GlobalApp];
-		gadget->handle=window;
-		gadget->view=[window clientView];
+		nativeHandle=window;
+		if ([window isKindOfClass:[ToolView class]]) clientView=[(ToolView*)window clientView];
+		else clientView=[(WindowView*)window clientView];
 		break;
 		
 	case GADGET_BUTTON:
 		button=[[NSButton alloc] initWithFrame:rect];
 		[button setTitle:text];
 		
-		[button setBezelStyle:NSRoundedBezelStyle];
+		[button setBezelStyle:NSBezelStyleRounded];
 		
 		switch (style&7){
 			case 0:
 				// Push Button Size Hack
-				if (gadget->h > 30) {
-					[button setBezelStyle:NSRegularSquareBezelStyle];
+				if (*h > 30) {
+					[button setBezelStyle:NSBezelStyleRegularSquare];
 				} else {
-					if (gadget->h < 24) [button setBezelStyle:NSShadowlessSquareBezelStyle];
-					else [button setBezelStyle:NSRoundedBezelStyle];
+					if (*h < 24) [button setBezelStyle:NSBezelStyleShadowlessSquare];
+					else [button setBezelStyle:NSBezelStyleRounded];
 				}
 				break;
 			case BUTTON_CHECKBOX:
 				if (style&BUTTON_PUSH){
-					[button setBezelStyle:NSShadowlessSquareBezelStyle];
-					[button setButtonType:NSPushOnPushOffButton];
+					[button setBezelStyle:NSBezelStyleShadowlessSquare];
+					[button setButtonType:NSButtonTypePushOnPushOff];
 				} else {
-					[button setButtonType:NSSwitchButton];
+					[button setButtonType:NSButtonTypeSwitch];
 				}
 				break;
 			case BUTTON_RADIO:
 				if (style&BUTTON_PUSH){
-					[button setBezelStyle:NSShadowlessSquareBezelStyle];
-					[button setButtonType:NSPushOnPushOffButton];
+					[button setBezelStyle:NSBezelStyleShadowlessSquare];
+					[button setButtonType:NSButtonTypePushOnPushOff];
 				} else {
-					[button setButtonType:NSRadioButton];
+					[button setButtonType:NSButtonTypeRadio];
 				}
 				break;
 			case BUTTON_OK:
@@ -2498,33 +3560,32 @@ void NSInitGadget(nsgadget *gadget){
 		[button setTarget:GlobalApp];
 		[button setAction:@selector(buttonPush:)];
 		if (view) [view addSubview:button];		
-		gadget->handle=button;
-		gadget->view=button;
+		nativeHandle=button;
+		clientView=button;
 		break;
 	case GADGET_PANEL:
 		panel=[[PanelView alloc] initWithFrame:rect];
 		[panel setContentViewMargins:NSMakeSize(0.0,0.0)];
-		pnlcontent=[[PanelViewContent alloc] initWithFrame:[[panel contentView] frame]];
+		pnlcontent=[[PanelViewContent alloc] initWithFrame:[panel bounds]];
 		[pnlcontent setAutoresizesSubviews:NO];
 		[panel setContentView:pnlcontent];
-		[panel setGadget:gadget];
+		[pnlcontent release];
 		[panel setStyle:style];
 		[panel setEnabled:true];
 		[panel setTitle:text];
 		[pnlcontent setAlpha:1.0];
 		if (view) [view addSubview:panel];
-		gadget->view=pnlcontent;
-		gadget->handle=panel;
+		clientView=pnlcontent;
+		nativeHandle=panel;
 		break;
 	case GADGET_CANVAS:
 		canvas=[[CanvasView alloc] initWithFrame:rect];
 		[canvas setAutoresizesSubviews:NO];
-		[canvas setGadget:gadget];
 		if (view) [view addSubview:canvas];
 		[canvas setStyle:style|PANEL_ACTIVE];
 		[canvas setEnabled:true];
-		gadget->view=[canvas contentView];
-		gadget->handle=canvas;
+		clientView=[canvas contentView];
+		nativeHandle=canvas;
 		break;	
 	case GADGET_TEXTFIELD:
 		if (style==TEXTFIELD_PASSWORD){
@@ -2537,16 +3598,16 @@ void NSInitGadget(nsgadget *gadget){
 		[[textfield cell] setWraps:NO];
 		[[textfield cell] setScrollable:YES];
 		if (view) [view addSubview:textfield];		
-		gadget->handle=textfield;
-		gadget->view=textfield;
+		nativeHandle=textfield;
+		clientView=textfield;
 		break;
 	case GADGET_TEXTAREA://http://developer.apple.com/documentation/Cocoa/Conceptual/TextUILayer/Tasks/TextInScrollView.html
 		textarea=[[TextView alloc] initWithFrame:rect];
 		if (style&TEXTAREA_READONLY) [textarea setEditable:NO];
 		if (style&TEXTAREA_WORDWRAP) [textarea setWordWrap:YES];
 		if (view) [view addSubview:[textarea getScroll]];
-		gadget->handle=textarea;
-		gadget->view=[textarea getScroll];// simon was here textarea;
+		nativeHandle=textarea;
+		clientView=[textarea getScroll];
 		break;		
 	case GADGET_COMBOBOX:
 		if (rect.size.height > 26) rect.size.height = 26;
@@ -2557,44 +3618,47 @@ void NSInitGadget(nsgadget *gadget){
 		[combobox setEditable:(style&COMBOBOX_EDITABLE)?YES:NO];			
 		[combobox setSelectable:YES];			
 		if (view) [view addSubview:combobox];		
-		gadget->handle=combobox;
-		gadget->view=combobox;
+		nativeHandle=combobox;
+		clientView=combobox;
 		break;
 	case GADGET_LISTBOX:
 		listbox=[[ListView alloc] initWithFrame:rect];
+		[[listbox table] setAllowsMultipleSelection:(style&LISTBOX_MULTISELECT)?YES:NO];
 		if (view) [view addSubview:listbox];		
-		gadget->handle=listbox;
-		gadget->view=listbox;
+		nativeHandle=listbox;
+		clientView=listbox;
 		break;
 	case GADGET_TOOLBAR:
 		toolbar=[[Toolbar alloc] initWithIdentifier:text];
-		[toolbar setSizeMode:NSToolbarSizeModeSmall];
+		[toolbar setSizeMode:NSToolbarSizeModeDefault];
 		[toolbar setDisplayMode:NSToolbarDisplayModeIconOnly];
-		[toolbar setDelegate:GlobalApp];
-		window=(WindowView*)group->handle;
+		[toolbar setDelegate:toolbar];
+		window=(WindowView*)groupHandle;
 		[window setToolbar:toolbar];
-		gadget->handle=toolbar;
-		gadget->view=[window clientView];
+		if (@available(macOS 11.0,*)) [window setToolbarStyle:NSWindowToolbarStyleExpanded];
+		nativeHandle=toolbar;
+		if ([window isKindOfClass:[ToolView class]]) clientView=[(ToolView*)window clientView];
+		else clientView=[(WindowView*)window clientView];
 		break;
 	case GADGET_TABBER:
 		tabber=[[TabView alloc] initWithFrame:rect];
 		[tabber setAutoresizesSubviews:NO];
 		if (view) [view addSubview:tabber];		//[tabber hostView]];		
-		gadget->handle=tabber;
-		gadget->view=[tabber clientView];
+		nativeHandle=tabber;
+		clientView=[tabber clientView];
 		break;
 	case GADGET_TREEVIEW:
 		treeview=[[TreeView alloc] initWithFrame:rect];	//NSOutlineView
 		if (view) [view addSubview:treeview];		
-		gadget->handle=treeview;
-		gadget->view=treeview;
+		nativeHandle=treeview;
+		clientView=treeview;
 		break;
 	case GADGET_HTMLVIEW:
 		htmlview=[[HTMLView alloc] initWithFrame:rect];
 		if (view) [view addSubview:htmlview];
 		[htmlview setStyle: style];
-		gadget->handle=htmlview;
-		gadget->view=htmlview;
+		nativeHandle=htmlview;
+		clientView=htmlview;
 		break;
     case GADGET_LABEL: /* BaH */
 		switch (style&3) {
@@ -2609,8 +3673,8 @@ void NSInitGadget(nsgadget *gadget){
 			[box setContentView:[[FlippedView alloc] init]];
 			
 			if (view) [view addSubview:box];
-			gadget->handle=box;
-			gadget->view=[box contentView];
+			nativeHandle=box;
+			clientView=[box contentView];
 			
 			break;
 			
@@ -2637,14 +3701,14 @@ void NSInitGadget(nsgadget *gadget){
 			[textfield setStringValue:text];
 			
 			switch (style&24){
-				case LABEL_LEFT:[textfield setAlignment:NSLeftTextAlignment];break;
-				case LABEL_RIGHT:[textfield setAlignment:NSRightTextAlignment];break;
-				case LABEL_CENTER:[textfield setAlignment:NSCenterTextAlignment];break;
+				case LABEL_LEFT:[textfield setAlignment:NSTextAlignmentLeft];break;
+				case LABEL_RIGHT:[textfield setAlignment:NSTextAlignmentRight];break;
+				case LABEL_CENTER:[textfield setAlignment:NSTextAlignmentCenter];break;
 			}               
 			
 			if (view) [view addSubview: textfield];
-			gadget->handle=textfield;
-			gadget->view=textfield;
+			nativeHandle=textfield;
+			clientView=textfield;
 			
 			break;
 		}
@@ -2653,98 +3717,129 @@ void NSInitGadget(nsgadget *gadget){
 		switch (style&12){
 		case SLIDER_SCROLLBAR:
 			if (rect.size.width>rect.size.height)		{
-				rect.size.height=[NSScroller scrollerWidth];
+				rect.size.height=MaxGUIScrollerWidth();
 			}
 			else{
-				rect.size.width=[NSScroller scrollerWidth];
+				rect.size.width=MaxGUIScrollerWidth();
 			}
 			scroller=[[NSScroller alloc] initWithFrame:rect];
 			[scroller setEnabled:YES];
-			[scroller setArrowsPosition:NSScrollerArrowsDefaultSetting];
+			[scroller setTarget:GlobalApp];
 			[scroller setAction:@selector(scrollerSelect:)];
 			if (view) [view addSubview:scroller];		
-			gadget->handle=scroller;
-			gadget->view=scroller;
+			nativeHandle=scroller;
+			clientView=scroller;
 			break;
 		case SLIDER_TRACKBAR:
 			slider=[[NSSlider alloc] initWithFrame:rect];
 			[slider setEnabled:YES];
+			[slider setTarget:GlobalApp];
 			[slider setAction:@selector(sliderSelect:)];
 			if (view) [view addSubview:slider];
-			gadget->handle=slider;
-			gadget->view=slider;
+			nativeHandle=slider;
+			clientView=slider;
+			break;
+		case SLIDER_DIAL:
+			slider=[[NSSlider alloc] initWithFrame:rect];
+			[slider setSliderType:NSSliderTypeCircular];
+			[slider setEnabled:YES];
+			[slider setTarget:GlobalApp];
+			[slider setAction:@selector(sliderSelect:)];
+			if (view) [view addSubview:slider];
+			nativeHandle=slider;
+			clientView=slider;
 			break;
 		case SLIDER_STEPPER:
 			stepper=[[NSStepper alloc] initWithFrame:rect];
 			[stepper setEnabled:YES];
+			[stepper setTarget:GlobalApp];
 			[stepper setAction:@selector(sliderSelect:)];
 			[stepper setValueWraps:NO];
 			if (view) [view addSubview:stepper];
-			gadget->handle=stepper;
-			gadget->view=stepper;
+			nativeHandle=stepper;
+			clientView=stepper;
 			break;
 		}
 		break;
 	case GADGET_PROGBAR:
 		progbar=[[NSProgressIndicator alloc] initWithFrame:rect];
-		[progbar setStyle:NSProgressIndicatorBarStyle];		
+		[progbar setStyle:NSProgressIndicatorStyleBar];
 		[progbar setIndeterminate:NO];
 		[progbar setMaxValue:1.0];
 		if (view) [view addSubview:progbar];		
-		gadget->handle=progbar;
-		gadget->view=progbar;
+		nativeHandle=progbar;
+		clientView=progbar;
 		break;
 	case GADGET_MENUITEM:
 		// Allows a popup-menu to be created with no text without crashing.
-		if ([text length] || (group->internalclass == GADGET_DESKTOP)) {
+		if ([text length] || groupClass==GADGET_DESKTOP) {
 			menuitem=[[NSMenuItem alloc] initWithTitle:text action:@selector(menuSelect:) keyEquivalent:@""];
 			[menuitem setTag:style];
-			[GlobalApp addMenuItem:menuitem];
 		}
 		else{
-			menuitem=(NSMenuItem*)[NSMenuItem separatorItem];
+			menuitem=[(NSMenuItem*)[NSMenuItem separatorItem] retain];
 		}
-		if (group){
-			switch (group->internalclass){
-				case GADGET_WINDOW:		
+		[menuitem setTarget:GlobalApp];
+		[GlobalApp addMenuItem:menuitem];
+		if (groupPeer){
+			switch (groupClass){
+				case GADGET_WINDOW:{
+					int role=MaxGUITopLevelMenuRole(text);
+					NSMenuItem *standardRoot=MaxGUITopLevelItem(role);
+					if (role==MAXGUI_TOP_MENU_WINDOW && [NSApp windowsMenu]){
+						MaxGUIRegisterTopMenuProxy(menuitem,[NSApp windowsMenu]);
+						break;
+					}
+					if (role==MAXGUI_TOP_MENU_VIEW && standardRoot && [standardRoot submenu]){
+						MaxGUIRegisterTopMenuProxy(menuitem,[standardRoot submenu]);
+						break;
+					}
 					menu=[[NSMenu alloc] initWithTitle:text];
 					[menu setAutoenablesItems:NO];
-					[menu setSubmenu:menu forItem:menuitem];
+					[menuitem setSubmenu:menu];
 					[menu release];
 					menu=[NSApp mainMenu];
-					[menu addItem:menuitem];
-					if ([text length]){
-						[menuitem release];
+					if (role==MAXGUI_TOP_MENU_HELP && ![NSApp helpMenu]){
+						[menu addItem:menuitem];
+						[NSApp setHelpMenu:[menuitem submenu]];
+					}else{
+						[menu insertItem:menuitem atIndex:MaxGUIApplicationMenuInsertionIndex()];
 					}
 					break;
-				case GADGET_MENUITEM:
-					menu=(NSMenu*)[group->handle submenu];
+				}
+				case GADGET_MENUITEM:{
+					int role=MaxGUIApplicationMenuRole(text);
+					if (role && MaxGUIMapApplicationMenuItem(menuitem,role)) break;
+					menu=MaxGUITopMenuProxy((NSMenuItem*)groupHandle);
+					if (!menu) menu=(NSMenu*)[groupHandle submenu];
 					if (!menu){
 						menu=(NSMenu*)[[NSMenu alloc] initWithTitle:text];
 						[menu setAutoenablesItems:NO];
-						[group->handle setSubmenu:menu];
+						[groupHandle setSubmenu:menu];
 						[menu addItem:menuitem];
 						[menu release];
 					} else {
 						[menu addItem:menuitem];
 					}
-					if ([text length]){
-						[menuitem release];
-					}
 					break;
+				}
 			}
 		}
-		gadget->handle=menuitem;
+		nativeHandle=menuitem;
+		// GlobalApp owns every menu item until its MaxGUI peer is freed. Menus
+		// retain attached items independently, so standalone popup roots follow
+		// the same deterministic ownership rule as window and submenu items.
+		[menuitem release];
 		break;
 	case GADGET_NODE:
-		if (!group) break;
+		if (!groupPeer) break;
 		parent=0;
-		switch (group->internalclass){
+		switch (groupClass){
 			case GADGET_TREEVIEW:
-				parent=[((TreeView*)group->handle) rootNode];
+				parent=[((TreeView*)groupHandle) rootNode];
 				break;
 			case GADGET_NODE:
-				parent=(NodeItem*)group->handle;
+				parent=(NodeItem*)groupHandle;
 				break;
 		}
 		if (!parent) break;
@@ -2753,13 +3848,599 @@ void NSInitGadget(nsgadget *gadget){
 		if (index==-1) index=[parent count];
 		if (index>[parent count]) index=[parent count];
 		[node attach:parent atIndex:index];
-		gadget->handle=node;
+		nativeHandle=node;
 		break;
 	}
+	NSPeerSetNativeObjects(peer,nativeHandle,clientView);
+}
+
+int NSMaxGUIMenuAttachment(void *rootHandle,void *childHandle){
+	NSMenuItem *root=(NSMenuItem*)rootHandle;
+	NSMenuItem *child=(NSMenuItem*)childHandle;
+	if (!root || !child) return 0;
+	NSMenu *submenu=MaxGUITopMenuProxy(root);
+	if (!submenu) submenu=[root submenu];
+	if (!submenu || [child menu]!=submenu) return 0;
+	if ([root target]!=GlobalApp || [child target]!=GlobalApp) return 0;
+	return 1;
+}
+
+int NSMaxGUIMenuPerformAction(void *handle){
+	NSMenuItem *item=(NSMenuItem*)handle;
+	if (!item || ![item action] || ![item target]) return 0;
+	return [NSApp sendAction:[item action] to:[item target] from:item];
+}
+
+int NSMaxGUIInstallTestApplicationMenus(){
+	if (MaxGUIApplicationMenu()) return 1;
+	NSMenu *mainMenu=[[NSMenu alloc] initWithTitle:@""];
+	[NSApp setMainMenu:mainMenu];
+	[mainMenu release];
+	NSMenu *appMenu=[[NSMenu alloc] initWithTitle:@""];
+	[appMenu addItemWithTitle:@"About Menu Test" action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
+	[appMenu addItem:[NSMenuItem separatorItem]];
+	[appMenu addItemWithTitle:@"Preferences…" action:@selector(showPreferences:) keyEquivalent:@","];
+	[appMenu addItem:[NSMenuItem separatorItem]];
+	[appMenu addItemWithTitle:@"Quit Menu Test" action:@selector(terminate:) keyEquivalent:@"q"];
+	NSMenuItem *root=[[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+	[root setSubmenu:appMenu];
+	[[NSApp mainMenu] addItem:root];
+	[root release];
+	[appMenu release];
+	NSMenu *viewMenu=[[NSMenu alloc] initWithTitle:@"View"];
+	[viewMenu addItemWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
+	root=[[NSMenuItem alloc] initWithTitle:@"View" action:nil keyEquivalent:@""];
+	[root setSubmenu:viewMenu];
+	[[NSApp mainMenu] addItem:root];
+	[root release];
+	[viewMenu release];
+	NSMenu *windowMenu=[[NSMenu alloc] initWithTitle:@"Window"];
+	[windowMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
+	root=[[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
+	[root setSubmenu:windowMenu];
+	[[NSApp mainMenu] addItem:root];
+	[root release];
+	[NSApp setWindowsMenu:windowMenu];
+	[windowMenu release];
+	MaxGUIAppMenu=nil;
+	return MaxGUIApplicationMenu()!=nil ? 1 : 0;
+}
+
+int NSMaxGUIApplicationMenuItemPresentation(void *handle,int role){
+	NSMenuItem *item=(NSMenuItem*)handle;
+	if (!item || role<=MAXGUI_APP_MENU_NONE || role>MAXGUI_APP_MENU_QUIT) return 0;
+	NSMenu *appMenu=MaxGUIApplicationMenu();
+	MaxGUIApplicationMenuBinding *binding=&MaxGUIAppMenuBindings[role];
+	int result=0;
+	if ([item menu]==appMenu) result|=1;
+	if (binding->mappedItem==item) result|=2;
+	if ([item target]==GlobalApp && [item action]==@selector(menuSelect:)) result|=4;
+	if ([appMenu indexOfItem:item]==binding->index) result|=8;
+	if (binding->standardItem && [[item keyEquivalent] isEqualToString:[binding->standardItem keyEquivalent]] &&
+		[item keyEquivalentModifierMask]==[binding->standardItem keyEquivalentModifierMask]) result|=16;
+	return result;
+}
+
+int NSMaxGUITopLevelMenuPresentation(void *handle,int role){
+	NSMenuItem *item=(NSMenuItem*)handle;
+	if (!item || role<=MAXGUI_TOP_MENU_NONE || role>MAXGUI_TOP_MENU_HELP) return 0;
+	NSMenu *submenu=MaxGUITopMenuProxy(item);
+	if (!submenu) submenu=[item submenu];
+	NSMenu *expected=nil;
+	if (role==MAXGUI_TOP_MENU_WINDOW) expected=[NSApp windowsMenu];
+	else if (role==MAXGUI_TOP_MENU_HELP) expected=[NSApp helpMenu];
+	else {
+		NSMenuItem *standard=MaxGUITopLevelItem(MAXGUI_TOP_MENU_VIEW);
+		expected=[standard submenu];
+	}
+	int result=0;
+	if (submenu && submenu==expected) result|=1;
+	NSInteger count=0;
+	for (NSMenuItem *root in [[NSApp mainMenu] itemArray]) if ([root submenu]==submenu) count++;
+	if (count==1) result|=2;
+	BOOL attached=[item menu]==[NSApp mainMenu];
+	if ((role==MAXGUI_TOP_MENU_HELP && attached) || (role!=MAXGUI_TOP_MENU_HELP && !attached)) result|=4;
+	NSMenuItem *visible=MaxGUITopLevelItem(role);
+	if (visible && [[NSApp mainMenu] indexOfItem:visible]>0) result|=8;
+	return result;
+}
+
+int NSMaxGUIMainMenuOrderPresentation(void *fileHandle,void *helpHandle){
+	NSMenu *mainMenu=[NSApp mainMenu];
+	NSMenuItem *file=(NSMenuItem*)fileHandle;
+	NSMenuItem *help=(NSMenuItem*)helpHandle;
+	NSMenuItem *view=MaxGUITopLevelItem(MAXGUI_TOP_MENU_VIEW);
+	NSMenuItem *window=MaxGUITopLevelItem(MAXGUI_TOP_MENU_WINDOW);
+	NSInteger appIndex=[mainMenu indexOfItemWithSubmenu:MaxGUIApplicationMenu()];
+	NSInteger fileIndex=[mainMenu indexOfItem:file];
+	NSInteger viewIndex=[mainMenu indexOfItem:view];
+	NSInteger windowIndex=[mainMenu indexOfItem:window];
+	NSInteger helpIndex=[mainMenu indexOfItem:help];
+	return appIndex>=0 && appIndex<fileIndex && fileIndex<viewIndex && viewIndex<windowIndex && windowIndex<helpIndex;
+}
+
+int NSMaxGUIApplicationMenuDefaultsPresentation(){
+	NSMenu *appMenu=MaxGUIApplicationMenu();
+	MaxGUIInitializeApplicationMenuBindings();
+	int result=0;
+	for (int role=MAXGUI_APP_MENU_ABOUT;role<=MAXGUI_APP_MENU_QUIT;role++){
+		NSInteger count=0;
+		for (NSMenuItem *item in [appMenu itemArray]) if ([item action]==MaxGUIAppMenuBindings[role].action) count++;
+		if (count==1 && !MaxGUIAppMenuBindings[role].mappedItem && !MaxGUIAppMenuBindings[role].standardItem) result|=1<<(role-1);
+	}
+	return result;
+}
+
+int NSMaxGUIHelpMenuIsClear(){
+	return [NSApp helpMenu]==nil ? 1 : 0;
+}
+
+int NSMaxGUIApplicationDelegatePresentation(){
+	id <NSApplicationDelegate> delegate=[NSApp delegate];
+	if (!delegate) return 0;
+	int result=1;
+	if ([delegate respondsToSelector:@selector(applicationShouldTerminate:)]) result|=2;
+	if ([delegate respondsToSelector:@selector(applicationWillTerminate:)]) result|=4;
+	if ([delegate respondsToSelector:@selector(applicationDidBecomeActive:)]) result|=8;
+	if ([delegate respondsToSelector:@selector(applicationDidResignActive:)]) result|=16;
+	if ([delegate respondsToSelector:@selector(application:openFile:)]) result|=32;
+	BOOL terminatesAfterLastWindow=NO;
+	if ([delegate respondsToSelector:@selector(applicationShouldTerminateAfterLastWindowClosed:)]){
+		terminatesAfterLastWindow=[delegate applicationShouldTerminateAfterLastWindowClosed:NSApp];
+	}
+	if (!terminatesAfterLastWindow) result|=64;
+	if (NSApp) result|=128;
+	return result;
+}
+
+int NSMaxGUIApplicationResumeAction(){
+	id <NSApplicationDelegate> delegate=[NSApp delegate];
+	if (!delegate || ![delegate respondsToSelector:@selector(applicationDidBecomeActive:)]) return 0;
+	[delegate applicationDidBecomeActive:[NSNotification notificationWithName:NSApplicationDidBecomeActiveNotification object:NSApp]];
+	return 1;
+}
+
+int NSMaxGUIApplicationSuspendAction(){
+	id <NSApplicationDelegate> delegate=[NSApp delegate];
+	if (!delegate || ![delegate respondsToSelector:@selector(applicationDidResignActive:)]) return 0;
+	[delegate applicationDidResignActive:[NSNotification notificationWithName:NSApplicationDidResignActiveNotification object:NSApp]];
+	return 1;
+}
+
+int NSMaxGUIApplicationTerminateAction(){
+	id <NSApplicationDelegate> delegate=[NSApp delegate];
+	if (!delegate || ![delegate respondsToSelector:@selector(applicationShouldTerminate:)]) return 0;
+	return [delegate applicationShouldTerminate:NSApp]==NSTerminateCancel ? 1 : 0;
+}
+
+int NSMaxGUIApplicationOpenFileAction(BBString *patharg){
+	id <NSApplicationDelegate> delegate=[NSApp delegate];
+	if (!delegate || ![delegate respondsToSelector:@selector(application:openFile:)]) return 0;
+	return [delegate application:NSApp openFile:NSStringFromBBString(patharg)] ? 1 : 0;
+}
+
+int NSMaxGUIButtonPerformClick(void *handle){
+	NSButton *button=(NSButton*)handle;
+	if (!button || ![button isKindOfClass:[NSButton class]]) return 0;
+	[button performClick:nil];
+	return 1;
+}
+
+int NSMaxGUIControlSetDoubleValueAndSendAction(void *handle,double value){
+	NSControl *control=(NSControl*)handle;
+	if (!control || ![control isKindOfClass:[NSControl class]]) return 0;
+	if (![control action] || ![control target]) return 0;
+	[control setDoubleValue:value];
+	return [control sendAction:[control action] to:[control target]] ? 1 : 0;
+}
+
+int NSMaxGUIItemDoubleAction(void *handle,int gadgetClass,int index){
+	if (!handle) return 0;
+	switch (gadgetClass){
+		case GADGET_LISTBOX:
+			if (![(id)handle isKindOfClass:[ListView class]]) return 0;
+			return [(ListView*)handle performDoubleActionAtIndex:index] ? 1 : 0;
+		case GADGET_TREEVIEW:
+			if (![(id)handle isKindOfClass:[TreeView class]]) return 0;
+			return [(TreeView*)handle performDoubleActionAtIndex:index] ? 1 : 0;
+	}
+	return 0;
+}
+
+int NSMaxGUIComboSelectionAction(void *handle,int index){
+	NSComboBox *combo=(NSComboBox*)handle;
+	if (!combo || ![combo isKindOfClass:[NSComboBox class]]) return 0;
+	if (index<0 || index>=[combo numberOfItems]) return 0;
+	[combo selectItemAtIndex:index];
+	[combo setObjectValue:[combo objectValueOfSelectedItem]];
+	NSNotification *notification=[NSNotification notificationWithName:NSComboBoxSelectionDidChangeNotification object:combo];
+	[GlobalApp controlTextDidChange:notification];
+	[GlobalApp comboBoxSelectionDidChange:notification];
+	return 1;
+}
+
+int NSMaxGUIComboEditAction(void *handle,BBString *textarg){
+	NSComboBox *combo=(NSComboBox*)handle;
+	if (!combo || ![combo isKindOfClass:[NSComboBox class]] || ![combo isEditable]) return 0;
+	NSInteger selected=[combo indexOfSelectedItem];
+	if (selected>=0) [combo deselectItemAtIndex:selected];
+	[combo setStringValue:NSStringFromBBString(textarg)];
+	NSNotification *notification=[NSNotification notificationWithName:NSControlTextDidChangeNotification object:combo];
+	[GlobalApp controlTextDidChange:notification];
+	return 1;
+}
+
+int NSMaxGUITabSelectionAction(void *handle,int index){
+	TabView *tabView=(TabView*)handle;
+	if (!tabView || ![tabView isKindOfClass:[TabView class]]) return 0;
+	return [tabView performUserSelectionAtIndex:index] ? 1 : 0;
+}
+
+int NSMaxGUITabOverflowPresentation(void *handle){
+	TabView *tabView=(TabView*)handle;
+	if (!tabView || ![tabView isKindOfClass:[TabView class]]) return 0;
+	return [tabView overflowPresentation];
+}
+
+int NSMaxGUIWindowPresentation(void *handle){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	int result=0;
+	if ([window isOpaque]) result|=1;
+	if (fabs([window alphaValue]-1.0)<0.0001) result|=2;
+	return result;
+}
+
+int NSMaxGUISetWindowAppearance(void *handle,int mode){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	NSAppearance *appearance=nil;
+	if (mode==0) appearance=[NSAppearance appearanceNamed:NSAppearanceNameAqua];
+	else if (mode==1) appearance=[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+	else if (mode!=-1) return 0;
+	[window setAppearance:appearance];
+	[[window contentView] setNeedsDisplay:YES];
+	[window displayIfNeeded];
+	return 1;
+}
+
+int NSMaxGUIWindowAppearance(void *handle){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return -2;
+	NSAppearance *appearance=[window appearance];
+	if (!appearance) return -1;
+	NSString *match=[appearance bestMatchFromAppearancesWithNames:[NSArray arrayWithObjects:NSAppearanceNameAqua,NSAppearanceNameDarkAqua,nil]];
+	if ([match isEqualToString:NSAppearanceNameAqua]) return 0;
+	if ([match isEqualToString:NSAppearanceNameDarkAqua]) return 1;
+	return -2;
+}
+
+int NSMaxGUIWindowCacheDisplay(void *handle){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	NSView *content=[window contentView];
+	NSRect bounds=[content bounds];
+	if (NSIsEmptyRect(bounds)) return 0;
+	NSBitmapImageRep *bitmap=[content bitmapImageRepForCachingDisplayInRect:bounds];
+	if (!bitmap) return 0;
+	[content cacheDisplayInRect:bounds toBitmapImageRep:bitmap];
+	return [bitmap pixelsWide]>0 && [bitmap pixelsHigh]>0 ? 1 : 0;
+}
+
+static NSData *MaxGUIWindowPNGData(NSWindow *window){
+	NSView *content=[window contentView];
+	NSRect bounds=[content bounds];
+	if (NSIsEmptyRect(bounds)) return nil;
+	[content layoutSubtreeIfNeeded];
+	[content setNeedsDisplay:YES];
+	[content displayIfNeededIgnoringOpacity];
+	NSBitmapImageRep *bitmap=[content bitmapImageRepForCachingDisplayInRect:bounds];
+	if (!bitmap) return nil;
+	[NSGraphicsContext saveGraphicsState];
+	[NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithBitmapImageRep:bitmap]];
+	[[window backgroundColor] setFill];
+	NSRectFill(bounds);
+	[NSGraphicsContext restoreGraphicsState];
+	[content cacheDisplayInRect:bounds toBitmapImageRep:bitmap];
+	return [bitmap representationUsingType:NSBitmapImageFileTypePNG properties:[NSDictionary dictionary]];
+}
+
+int NSMaxGUIWindowWritePNG(void *handle,BBString *patharg){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]] || !patharg) return 0;
+	NSString *path=NSStringFromBBString(patharg);
+	if (@available(macOS 11.0,*)){
+		__block BOOL written=NO;
+		[[window effectiveAppearance] performAsCurrentDrawingAppearance:^{
+			written=[MaxGUIWindowPNGData(window) writeToFile:path atomically:YES];
+		}];
+		return written ? 1 : 0;
+	}
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	NSAppearance *previous=[NSAppearance currentAppearance];
+	[NSAppearance setCurrentAppearance:[window effectiveAppearance]];
+	BOOL written=[MaxGUIWindowPNGData(window) writeToFile:path atomically:YES];
+	[NSAppearance setCurrentAppearance:previous];
+#pragma clang diagnostic pop
+	return written ? 1 : 0;
+}
+
+int NSMaxGUIBackgroundState(void *handle,int gadgetClass){
+	if (!handle) return -1;
+	NSColor *color=nil;
+	NSColor *semantic=nil;
+	BOOL drawsBackground=NO;
+	BOOL secondaryDrawsBackground=NO;
+	switch (gadgetClass){
+		case GADGET_BUTTON:{
+			if (![(id)handle isKindOfClass:[NSButton class]]) return -1;
+			color=[[(NSButton*)handle cell] backgroundColor];
+			break;
+		}
+		case GADGET_WINDOW:
+			if (![(id)handle isKindOfClass:[NSWindow class]]) return -1;
+			color=[(NSWindow*)handle backgroundColor];
+			semantic=[NSColor windowBackgroundColor];
+			drawsBackground=[(NSWindow*)handle isOpaque];
+			break;
+		case GADGET_LABEL:
+		case GADGET_COMBOBOX:
+		case GADGET_TEXTFIELD:
+			if (![(id)handle isKindOfClass:[NSTextField class]]) return -1;
+			color=[(NSTextField*)handle backgroundColor];
+			semantic=[NSColor textBackgroundColor];
+			drawsBackground=[(NSTextField*)handle drawsBackground];
+			break;
+		case GADGET_LISTBOX:{
+			if (![(id)handle isKindOfClass:[ListView class]]) return -1;
+			NSTableView *table=[(ListView*)handle table];
+			color=[table backgroundColor];
+			semantic=[NSColor controlBackgroundColor];
+			drawsBackground=YES;
+			break;
+		}
+		case GADGET_TREEVIEW:{
+			if (![(id)handle isKindOfClass:[TreeView class]]) return -1;
+			NSOutlineView *outline=((TreeView*)handle)->outline;
+			color=[outline backgroundColor];
+			semantic=[NSColor controlBackgroundColor];
+			drawsBackground=YES;
+			break;
+		}
+		case GADGET_TEXTAREA:{
+			if (![(id)handle isKindOfClass:[TextView class]]) return -1;
+			TextView *textView=(TextView*)handle;
+			color=[textView backgroundColor];
+			semantic=[NSColor textBackgroundColor];
+			drawsBackground=[textView drawsBackground];
+			secondaryDrawsBackground=[[textView getScroll] drawsBackground];
+			break;
+		}
+		case GADGET_PANEL:{
+			if (![(id)handle isKindOfClass:[PanelView class]]) return -1;
+			return [[(PanelView*)handle contentView] hasColor] ? 1 : 0;
+		}
+		default:
+			return -1;
+	}
+	int result=color ? 1 : 0;
+	if (drawsBackground) result|=2;
+	if (color && semantic && [color isEqual:semantic]) result|=4;
+	if (secondaryDrawsBackground) result|=8;
+	return result;
+}
+
+int NSMaxGUIWindowStatusPresentation(void *handle){
+	id window=(id)handle;
+	if (![window isKindOfClass:[WindowView class]] && ![window isKindOfClass:[ToolView class]]) return 0;
+	NSArray *expected=[NSArray arrayWithObjects:@"left",@"center",@"right",nil];
+	NSTextAlignment alignments[3]={NSTextAlignmentLeft,NSTextAlignmentCenter,NSTextAlignmentRight};
+	BOOL modern=YES;
+	BOOL text=YES;
+	BOOL alignment=YES;
+	BOOL behavior=YES;
+	BOOL semantic=YES;
+	BOOL geometry=YES;
+	NSView *root=[window contentView];
+	for (NSInteger i=0;i<3;i++){
+		id statusLabel=[window statusLabelAtIndex:i];
+		if (![statusLabel isKindOfClass:[NSTextField class]]) modern=NO;
+		NSString *value=[statusLabel respondsToSelector:@selector(stringValue)] ? [statusLabel stringValue] : [statusLabel string];
+		if (![value isEqualToString:[expected objectAtIndex:i]]) text=NO;
+		if ([statusLabel alignment]!=alignments[i]) alignment=NO;
+		if ([statusLabel drawsBackground] || [statusLabel isEditable] || [statusLabel isSelectable]) behavior=NO;
+		if (![[statusLabel textColor] isEqual:[NSColor secondaryLabelColor]]) semantic=NO;
+		if (!NSContainsRect([root bounds],[statusLabel frame])) geometry=NO;
+	}
+	int result=modern ? 1 : 0;
+	if (text) result|=2;
+	if (alignment) result|=4;
+	if (behavior) result|=8;
+	if (semantic) result|=16;
+	if (geometry) result|=32;
+	return result;
+}
+
+int NSMaxGUIToolbarPresentation(void *toolbarHandle,void *windowHandle,int width,int height){
+	if (!toolbarHandle || ![(id)toolbarHandle isKindOfClass:[Toolbar class]]) return 0;
+	if (!windowHandle || (![(id)windowHandle isKindOfClass:[WindowView class]] && ![(id)windowHandle isKindOfClass:[ToolView class]])) return 0;
+	Toolbar *toolbar=(Toolbar*)toolbarHandle;
+	NSWindow *window=(NSWindow*)windowHandle;
+	int result=[toolbar sizeMode]!=NSToolbarSizeModeSmall ? 1 : 0;
+	if ([toolbar displayMode]==NSToolbarDisplayModeIconOnly) result|=2;
+	if ([window toolbar]==toolbar) result|=4;
+	BOOL expanded=YES;
+	if (@available(macOS 11.0,*)) expanded=[window toolbarStyle]==NSWindowToolbarStyleExpanded;
+	if (expanded) result|=8;
+	if ([toolbar isVisible]) result|=16;
+	NSView *client=[window isKindOfClass:[ToolView class]] ? [(ToolView*)window clientView] : [(WindowView*)window clientView];
+	NSSize clientSize=[client frame].size;
+	if (fabs(clientSize.width-width)<0.0001 && fabs(clientSize.height-height)<0.0001) result|=32;
+	return result;
+}
+
+int NSMaxGUIEmitMouseMovedForTest(void *handle){
+	void *peer=NSPeerForNativeHandle(handle);
+	NSView *view=(NSView*)(peer ? NSPeerClientView(peer) : handle);
+	if (!view || ![(id)view isKindOfClass:[NSView class]]) return 0;
+	CGEventRef cgEvent=CGEventCreateMouseEvent(NULL,kCGEventMouseMoved,CGPointMake(0,0),kCGMouseButtonLeft);
+	if (!cgEvent) return 0;
+	NSEvent *event=[NSEvent eventWithCGEvent:cgEvent];
+	int result=event ? EmitMouseEvent(event,view) : 0;
+	CFRelease(cgEvent);
+	return result;
+}
+
+int NSMaxGUIWindowUserRect(void *handle,int x,int y,int width,int height){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[WindowView class]]) return 0;
+	void *peer=NSPeerForNativeHandle(handle);
+	if (!peer) return 0;
+	int style=NSPeerGadgetStyle(peer);
+	NSRect rect=NSMakeRect(x,y,width,height);
+	NSRect visible=[[NSScreen deepestScreen] visibleFrame];
+	rect.origin.x+=visible.origin.x;
+	rect.origin.y=visible.origin.y+visible.size.height-rect.origin.y-rect.size.height;
+	if (style&WINDOW_CLIENTCOORDS){
+		if (style&WINDOW_STATUS){
+			rect.origin.y-=STATUSBARHEIGHT;
+			rect.size.height+=STATUSBARHEIGHT;
+		}
+		rect=[window frameRectForContentRect:rect];
+	}
+	[window setFrame:rect display:NO];
+	return 1;
+}
+
+int NSMaxGUIWindowActivateAction(void *handle){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	[GlobalApp windowDidBecomeKey:[NSNotification notificationWithName:NSWindowDidBecomeKeyNotification object:window]];
+	return 1;
+}
+
+int NSMaxGUIWindowCloseAction(void *handle){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	return [GlobalApp windowShouldClose:window] ? 0 : 1;
+}
+
+int NSMaxGUIWindowFileDropAction(void *handle,BBString *patharg,int x,int y){
+	NSWindow *window=(NSWindow*)handle;
+	if (!window || ![window isKindOfClass:[NSWindow class]]) return 0;
+	PostGuiEvent(BBEVENT_WINDOWACCEPT,window,0,0,x,y,(BBObject*)patharg);
+	return 1;
+}
+
+int NSMaxGUITextFieldEditAction(void *handle,BBString *textarg){
+	NSTextField *field=(NSTextField*)handle;
+	if (!field || ![field isKindOfClass:[NSTextField class]] || ![field isEditable]) return 0;
+	[field setStringValue:NSStringFromBBString(textarg)];
+	[GlobalApp controlTextDidChange:[NSNotification notificationWithName:NSControlTextDidChangeNotification object:field]];
+	return 1;
+}
+
+int NSMaxGUITextFieldEndEditingAction(void *handle){
+	NSTextField *field=(NSTextField*)handle;
+	if (!field || ![field isKindOfClass:[NSTextField class]]) return 0;
+	[GlobalApp controlTextDidEndEditing:[NSNotification notificationWithName:NSControlTextDidEndEditingNotification object:field]];
+	return 1;
+}
+
+int NSMaxGUIFilterAction(void *handle,int key,int mods,int character){
+	void *peer=NSPeerForNativeHandle(handle);
+	if (!peer) return 0;
+	if (character) return maxgui_cocoamaxgui_cocoagui_FilterChar(peer,key,mods);
+	return maxgui_cocoamaxgui_cocoagui_FilterKeyDown(peer,key,mods);
+}
+
+int NSMaxGUITextAreaReplaceSelectionAction(void *handle,BBString *textarg){
+	TextView *textView=(TextView*)handle;
+	if (!textView || ![textView isKindOfClass:[TextView class]] || ![textView isEditable]) return 0;
+	NSRange range=[textView selectedRange];
+	if (NSMaxRange(range)>[[textView string] length]) return 0;
+	if ([textView window]) [[textView window] makeFirstResponder:textView];
+	[textView insertText:NSStringFromBBString(textarg) replacementRange:range];
+	return 1;
+}
+
+int NSMaxGUITextAreaSelectionAction(void *handle,int location,int length){
+	TextView *textView=(TextView*)handle;
+	if (!textView || ![textView isKindOfClass:[TextView class]]) return 0;
+	if (location<0 || length<0 || (NSUInteger)location>[[textView string] length] || (NSUInteger)length>[[textView string] length]-(NSUInteger)location) return 0;
+	[textView setSelectedRange:NSMakeRange((NSUInteger)location,(NSUInteger)length)];
+	return 1;
+}
+
+int NSMaxGUITreeSelectionAction(void *handle,int index){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	return [treeView performUserSelectionAtIndex:index] ? 1 : 0;
+}
+
+int NSMaxGUITreeExpansionAction(void *handle,int index,int expand){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	return [treeView performUserExpansionAtIndex:index expand:expand ? YES : NO] ? 1 : 0;
+}
+
+int NSMaxGUITreeExpanded(void *handle,int index){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	return [treeView isItemExpandedAtIndex:index] ? 1 : 0;
+}
+
+int NSMaxGUITreeVisibleRowCount(void *handle){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return -1;
+	return (int)[treeView->outline numberOfRows];
+}
+
+int NSMaxGUITreeRowPresentation(void *handle){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	NSOutlineView *outlineView=treeView->outline;
+	[outlineView layoutSubtreeIfNeeded];
+	NSInteger rowCount=[outlineView numberOfRows];
+	for (NSView *view in [outlineView subviews]){
+		if (![view isKindOfClass:[NSTableRowView class]] || [view isHidden]) continue;
+		NSInteger row=[outlineView rowForView:view];
+		if (row<0 || row>=rowCount) return 0;
+	}
+	return 1;
+}
+
+int NSMaxGUITreeDragHooks(void *handle){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	OutlineView *outlineView=(OutlineView*)treeView->outline;
+	if (![outlineView isKindOfClass:[OutlineView class]]) return 0;
+	return [outlineView respondsToSelector:@selector(mouseDragged:)] && [outlineView respondsToSelector:@selector(rightMouseDragged:)] && [outlineView respondsToSelector:@selector(otherMouseDragged:)] ? 1 : 0;
+}
+
+int NSMaxGUITreeDragAction(void *handle,int index,int button,int mods,int x,int y){
+	TreeView *treeView=(TreeView*)handle;
+	if (!treeView || ![treeView isKindOfClass:[TreeView class]]) return 0;
+	void *treePeer=NSPeerForNativeHandle(handle);
+	if (!treePeer || !(NSPeerGadgetStyle(treePeer)&TREEVIEW_DRAGNDROP)) return 0;
+	if (index<0 || index>=[treeView->outline numberOfRows]) return 0;
+	id node=[treeView->outline itemAtRow:index];
+	return maxgui_cocoamaxgui_cocoagui_PostCocoaTreeDragEvent(treePeer,node,button,mods,x,y);
+}
+
+int NSMaxGUIGadgetDropAction(void *handle,int button,int mods,int x,int y){
+	void *targetPeer=NSPeerForNativeHandle(handle);
+	if (!targetPeer) return 0;
+	return maxgui_cocoamaxgui_cocoagui_PostCocoaGadgetDropEvent(targetPeer,button,mods,x,y);
+}
+
+int NSMaxGUICancelDragAction(int button){
+	return maxgui_cocoamaxgui_cocoagui_CancelCocoaGadgetDrag(button);
 }
 
 @class color_delegate;
-@interface color_delegate:NSObject{}
+@interface color_delegate:NSObject <NSWindowDelegate>{}
 @end
 @implementation color_delegate
 - (void)windowWillClose:(NSNotification *)aNotification{[NSApp stopModal];}
@@ -2770,23 +4451,25 @@ int NSColorRequester(int r,int g,int b){
 	NSColor			*color;
 	color_delegate	*dele;
 	dele=[[color_delegate alloc] init];
-	color=[NSColor colorWithCalibratedRed:r/255.0L green:g/255.0L blue:b/255.0L alpha:1.0];
+	color=MaxGUIRGBColor(r,g,b);
 	panel=[NSColorPanel sharedColorPanel];
 	[panel setColor:color];
 	[panel setDelegate:dele];
 	[NSApp runModalForWindow:panel];
 	color=[panel color];
 	if (color){
-		color=[color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+		color=[color colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 		r=(int)((255*[color redComponent])+0.5);
 		g=(int)((255*[color greenComponent])+0.5);
 		b=(int)((255*[color blueComponent])+0.5);
 	}
+	[panel setDelegate:nil];
+	[dele release];
 	return 0xff000000|(r<<16)|(g<<8)|b;
 }
 
 @class font_delegate;
-@interface font_delegate:NSObject{
+@interface font_delegate:NSObject <NSWindowDelegate>{
 	NSFont		*_font;
 }
 -(id)initWithFont:(NSFont*)font;
@@ -2794,18 +4477,29 @@ int NSColorRequester(int r,int g,int b){
 -(id)font;
 -(void)windowWillClose:(NSNotification *)aNotification;
 -(unsigned int)validModesForFontPanel:(NSFontPanel *)fontPanel;
+-(void)dealloc;
 @end
 @implementation font_delegate
 -(id)initWithFont:(NSFont*)font{
-	_font=font;
+	self=[super init];
+	if (self) _font=[font retain];
 	return self;
 }
 -(id)font{
 	return _font;
 }
 -(void)changeFont:(id)sender{
-	_font=[sender convertFont:_font];
+	NSFont *font=[sender convertFont:_font];
+	if (font!=_font){
+		[font retain];
+		[_font release];
+		_font=font;
+	}
 	return; 
+}
+-(void)dealloc{
+	[_font release];
+	[super dealloc];
 }
 - (void)windowWillClose:(NSNotification *)aNotification{
 	[NSApp stopModal];
@@ -2817,13 +4511,13 @@ int NSColorRequester(int r,int g,int b){
 
 int NSGetSysColor( int colorindex, int* red, int* green, int* blue ){
 	
-	float r, g, b;
+	CGFloat r, g, b;
 	NSColor* c;
 	NSWindow* w;
 	
 	switch(colorindex){
 		case GUICOLOR_WINDOWBG:
-			w = [[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSTitledWindowMask backing:NSBackingStoreBuffered defer:YES];
+			w = [[NSWindow alloc] initWithContentRect:NSZeroRect styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:YES];
 			c = [w backgroundColor];
 			[w release];
 			break;
@@ -2841,7 +4535,7 @@ int NSGetSysColor( int colorindex, int* red, int* green, int* blue ){
 			break;
 	}
 	
-	[[c colorUsingColorSpaceName:NSCalibratedRGBColorSpace] getRed:&r green:&g blue:&b alpha:NULL];
+	[[c colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]] getRed:&r green:&g blue:&b alpha:NULL];
 	*red = (int)(255 * r);
 	*green = (int)(255 * g);
 	*blue = (int)(255 * b);
@@ -2852,6 +4546,7 @@ int NSGetSysColor( int colorindex, int* red, int* green, int* blue ){
 NSFont *NSRequestFont(NSFont *font){
 	NSFontPanel		*panel;
 	font_delegate		*dele;
+	BOOL hadInput=font!=nil;
 	if (!font) font=[NSFont userFontOfSize:0];
 	dele=[[font_delegate alloc] initWithFont:font];
 	panel=[NSFontPanel sharedFontPanel];
@@ -2859,7 +4554,11 @@ NSFont *NSRequestFont(NSFont *font){
 	[panel setEnabled:YES];
 	[panel setDelegate:dele];
 	[NSApp runModalForWindow:panel];
-	return [dele font];
+	NSFont *result=[dele font];
+	if (!hadInput || result!=font) [result retain];
+	[panel setDelegate:nil];
+	[dele release];
+	return result;
 }
 
 NSFont *NSLoadFont(BBString *name,double size,int flags){
@@ -2913,77 +4612,93 @@ void* NSSuperview(NSView* handle){
 
 // generic gadget commands
 
-void NSFreeGadget(nsgadget *gadget){
-	nsgadget *group;
-	NSWindow *parent;
+void NSPeerFreeGadget(void *peer){
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	id handle=NSPeerNativeHandle(peer);
+	NSView *view=NSPeerClientView(peer);
 	TextView *textview;
-	FlippedView * flipped;
-	if (gadget->textcolor){
-		[gadget->textcolor release];
-		gadget->textcolor = 0;
-	}
-	if (gadget->handle){
-		switch (gadget->internalclass){
+	FlippedView *flipped;
+	if (handle){
+		switch (gadgetClass){
 		case GADGET_WINDOW:
-			if ([gadget->handle parentWindow]!=nil){			
-				[[gadget->handle parentWindow] removeChildWindow:(NSWindow*)gadget->handle];
+			if ([handle parentWindow]!=nil){
+				[[handle parentWindow] removeChildWindow:(NSWindow*)handle];
 			}			
-			[gadget->handle close];
+			[handle close];
 			break;
 		case GADGET_NODE:
-			[gadget->handle remove];
-			[gadget->handle autorelease];
+			[handle remove];
 			break;
 		case GADGET_MENUITEM:
-			[GlobalApp removeMenuItem:gadget->handle];
-			[[gadget->handle menu] removeItem:gadget->handle];
+			MaxGUIPrepareMenuItemForFree((NSMenuItem*)handle);
+			[[handle menu] removeItem:handle];
+			[GlobalApp removeMenuItem:handle];
 			break;
 		case GADGET_TEXTAREA:
-			textview=(TextView*)gadget->handle;					
-			[gadget->view removeFromSuperview];
+			textview=(TextView*)handle;
+			[view removeFromSuperview];
 			[textview free];
 			[textview autorelease];
 			break;
 		case GADGET_LABEL:
-			switch (gadget->style&3) {
+			switch (gadgetStyle&3) {
 			case LABEL_SEPARATOR:
-				flipped=(FlippedView*)gadget->view;
+				flipped=(FlippedView*)view;
 				[flipped removeFromSuperview];
-				[gadget->handle removeFromSuperview];
+				[handle removeFromSuperview];
 				[flipped release];
 				break;
 			default:
-				[gadget->view removeFromSuperview];
+				[view removeFromSuperview];
 				break;
 			}
-			[gadget->handle autorelease];
+			[handle autorelease];
 			break;
 		case GADGET_TABBER:
-			flipped=(FlippedView*)gadget->view;
+			flipped=(FlippedView*)view;
+			[handle setDelegate:nil];
 			[flipped removeFromSuperview];
-			[gadget->handle removeFromSuperview];
-			[flipped release];
-			//Cocoa throws an exception if items exist when handle is autoreleased.
-			NSClearItems(gadget);
-			[gadget->handle autorelease];
+			[handle removeFromSuperview];
+			// Cocoa throws an exception if items exist when handle is autoreleased.
+			[(TabView*)handle removeAllItemsForFree];
+			[handle autorelease];
+			break;
+		case GADGET_TOOLBAR:
+			if ([[view window] toolbar]==handle) [[view window] setToolbar:nil];
+			[handle setDelegate:nil];
+			[handle autorelease];
 			break;
 		case GADGET_PANEL:
-			[gadget->handle setColor:nil];
-			[gadget->handle removeFromSuperview];
-			[gadget->handle autorelease];
+			[(PanelView*)handle setColor:nil];
+			[handle removeFromSuperview];
+			[handle release];
+			break;
+		case GADGET_CANVAS:
+			[handle removeFromSuperview];
+			[handle autorelease];
+			break;
+		case GADGET_TEXTFIELD:
+		case GADGET_COMBOBOX:
+			[NSObject cancelPreviousPerformRequestsWithTarget:[CocoaApp class] selector:@selector(delayedGadgetAction:) object:handle];
+			[handle setDelegate:nil];
+			[[view superview] setNeedsDisplayInRect:[view frame]];
+			[view removeFromSuperview];
+			[handle autorelease];
 			break;
 		default:
-			[[gadget->view superview] setNeedsDisplayInRect:[gadget->view frame]];
-			[gadget->view removeFromSuperview];
-			[gadget->handle autorelease];
+			[[view superview] setNeedsDisplayInRect:[view frame]];
+			[view removeFromSuperview];
+			[handle autorelease];
 			break;
 		}	
 	}
-	gadget->handle=0;
+	NSPeerSetNativeObjects(peer,0,0);
 }
 
-void NSEnable(nsgadget *gadget,int state){
-	switch (gadget->internalclass){
+void NSPeerSetEnabled(void *peer,int state){
+	id handle=NSPeerNativeHandle(peer);
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_WINDOW:
 	case GADGET_SLIDER:
 	case GADGET_TEXTFIELD:
@@ -2992,77 +4707,82 @@ void NSEnable(nsgadget *gadget,int state){
 	case GADGET_LISTBOX:
 	case GADGET_COMBOBOX:
 	case GADGET_TREEVIEW:
+	case GADGET_TABBER:
 	case GADGET_PANEL:
 	case GADGET_CANVAS:
-		[gadget->handle setEnabled:state];
+		[handle setEnabled:state];
 		break;
 	case GADGET_TEXTAREA:
-		[gadget->handle setSelectable:state];
-		if (!(gadget->style&TEXTAREA_READONLY)) [gadget->handle setEditable:state];
+		[handle setSelectable:state];
+		if (!(NSPeerGadgetStyle(peer)&TEXTAREA_READONLY)) [handle setEditable:state];
 		break;
 	}
 }
 
-void NSShow(nsgadget *gadget,int state){
-	switch (gadget->internalclass){
+void NSPeerSetShown(void *peer,int state){
+	id handle=NSPeerNativeHandle(peer);
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_WINDOW:
-		if (state==[gadget->handle isVisible]) return;
+		if (state==[handle isVisible]) return;
 		if (state) {
-			if((gadget->group!=&bbNullObject) && (gadget->group->internalclass==GADGET_WINDOW) &&
-			([gadget->handle parentWindow]==nil)) [gadget->group->handle addChildWindow: gadget->handle ordered:NSWindowAbove];
-			[gadget->handle makeKeyAndOrderFront:NSApp];
+			void *parentPeer=NSPeerParent(peer);
+			if(parentPeer && (NSPeerGadgetClass(parentPeer)==GADGET_WINDOW) &&
+			([handle parentWindow]==nil)) [(NSWindow*)NSPeerNativeHandle(parentPeer) addChildWindow:handle ordered:NSWindowAbove];
+			[handle makeKeyAndOrderFront:NSApp];
 		} else {
-			if([gadget->handle parentWindow]!=nil) [[gadget->handle parentWindow] removeChildWindow:(NSWindow*)gadget->handle];
-			[gadget->handle orderOut:NSApp];
+			if([handle parentWindow]!=nil) [[handle parentWindow] removeChildWindow:(NSWindow*)handle];
+			[handle orderOut:NSApp];
 		}
 		break;
 	case GADGET_TOOLBAR:
-		[gadget->handle setVisible:state];
+		[handle setVisible:state];
 		break;
 	default:
-		[gadget->handle setHidden:!state];
+		[handle setHidden:!state];
 	}
 }
 
-void NSCheck(nsgadget *gadget,int state){
+void NSPeerSetChecked(void *peer,int state){
 	NSButton			*button;
-	switch (gadget->internalclass){
+	id handle=NSPeerNativeHandle(peer);
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_MENUITEM:
-		[gadget->handle setState:state];
+		[handle setState:state];
 		break;
 	case GADGET_BUTTON:
-		button=(NSButton *)gadget->handle;
-		if(state==NSMixedState) [button setAllowsMixedState:YES]; else [button setAllowsMixedState:NO];
+		button=(NSButton *)handle;
+		if(state==NSControlStateValueMixed) [button setAllowsMixedState:YES]; else [button setAllowsMixedState:NO];
 		[button setState:state];
 		break; 
 	}
 }
 
-void NSPopupMenu(nsgadget *gadget,nsgadget *menugadget){
+void NSPeerPopupMenu(void *peer,void *menuPeer){
 	NSView			*view;
 	NSWindow			*window;
 	NSMenuItem		*menuitem;
 	NSEvent			*event;
 	NSPoint			loc;
 	
-	window=(NSWindow*)gadget->handle;
-	view=gadget->view;
-	menuitem=(NSMenuItem*)menugadget->handle;
+	window=(NSWindow*)NSPeerNativeHandle(peer);
+	view=NSPeerClientView(peer);
+	menuitem=(NSMenuItem*)NSPeerNativeHandle(menuPeer);
+	if (![menuitem submenu]) return;
 	event=[NSEvent 
-		mouseEventWithType:NSRightMouseUp 
-		location:[window convertScreenToBase:[NSEvent mouseLocation]]
-		modifierFlags:(NSEventModifierFlags)nil 
+		mouseEventWithType:NSEventTypeRightMouseUp
+		location:[window convertPointFromScreen:[NSEvent mouseLocation]]
+		modifierFlags:0
 		timestamp:0 
 		windowNumber:[window windowNumber] 
      	context:nil
-		eventNumber:(NSInteger)nil
+		eventNumber:0
 		clickCount:1 
 		pressure:0];
 	[NSMenu popUpContextMenu:[menuitem submenu] withEvent:event forView:view];		
 //	[event release];
 }
 
-int NSState(nsgadget *gadget){
+int NSPeerState(void *peer){
 	NSWindow		*window;
 	TextView		*textview;
 	NSButton		*button;
@@ -3071,66 +4791,68 @@ int NSState(nsgadget *gadget){
 	HTMLView		*browser;
 	NSMenuItem 	*menuItem;
 	int			state;
+	id handle=NSPeerNativeHandle(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
 
 	state=0;
 
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_TEXTAREA:
-		textview=(TextView*)gadget->handle;
+		textview=(TextView*)handle;
 		if ([textview isHidden]) state|=STATE_HIDDEN;
-		if ((!(gadget->style&TEXTAREA_READONLY)) && (![textview isEditable])) state|=STATE_DISABLED;
+		if ((!(gadgetStyle&TEXTAREA_READONLY)) && (![textview isEditable])) state|=STATE_DISABLED;
 		break;
 	case GADGET_HTMLVIEW:
-		browser=(HTMLView*)gadget->handle;
+		browser=(HTMLView*)handle;
 		return [browser loaded];
 	case GADGET_WINDOW:
-		window=(NSWindow*)gadget->handle;
+		window=(NSWindow*)handle;
 		if ([window isMiniaturized]) state|=STATE_MINIMIZED;
 		if ([window isZoomed]) state|=STATE_MAXIMIZED;
 		if (![window isVisible]) state|=STATE_HIDDEN;
 		break;
 	case GADGET_MENUITEM:
-		menuItem=(NSMenuItem*)gadget->handle;
-		if ([menuItem state]==NSOnState) state|=STATE_SELECTED;
+		menuItem=(NSMenuItem*)handle;
+		if ([menuItem state]==NSControlStateValueOn) state|=STATE_SELECTED;
 		if (![menuItem isEnabled]) state|=STATE_DISABLED;
 		break;
 	case GADGET_BUTTON:
-		button=(NSButton *)gadget->handle;
-		switch (gadget->style&7){
+		button=(NSButton *)handle;
+		switch (gadgetStyle&7){
 			case BUTTON_RADIO: case BUTTON_CHECKBOX:
-			if ([button state]==NSOnState) state|=STATE_SELECTED;
-			if ([button state]==NSMixedState) state|=STATE_INDETERMINATE;
+			if ([button state]==NSControlStateValueOn) state|=STATE_SELECTED;
+			if ([button state]==NSControlStateValueMixed) state|=STATE_INDETERMINATE;
 		}
 		if ([button isHidden]) state|=STATE_HIDDEN;
 		if (![button isEnabled]) state|=STATE_DISABLED;
 		break;
 	case GADGET_TOOLBAR:
-		toolbar=(Toolbar*)gadget->handle;
+		toolbar=(Toolbar*)handle;
 		if ([toolbar isVisible]==NO) state|=STATE_HIDDEN;
 		break;		
 	case GADGET_PROGBAR:
-		view=(NSView*)gadget->handle;
+		view=(NSView*)handle;
 		if ([view isHidden]) state|=STATE_HIDDEN;
 		break;
 	default:
-		view=(NSView*)gadget->handle;
+		view=(NSView*)handle;
 		if ([view isHidden]) state|=STATE_HIDDEN;
-		if (![view isEnabled]) state|=STATE_DISABLED;
+		if ([view respondsToSelector:@selector(isEnabled)] && ![(id)view isEnabled]) state|=STATE_DISABLED;
 		break;
 	}
 	return state;
 }
 
-void NSSetMinimumSize(nsgadget *gadget,int width,int height){
+void NSPeerSetMinimumSize(void *peer,int width,int height){
 	NSWindow	*window;
 	NSRect	rect;
 	int		style;
-	window=(NSWindow*)gadget->handle;
+	window=(NSWindow*)NSPeerNativeHandle(peer);
 	rect.origin.x=0;
 	rect.origin.y=0;
 	rect.size.width=width;
 	rect.size.height=height;
-	style=gadget->style;
+	style=NSPeerGadgetStyle(peer);
 	if (!(style&WINDOW_CLIENTCOORDS)){
 		rect=[window contentRectForFrameRect:rect];
 		rect.size.width-=rect.origin.x;
@@ -3141,16 +4863,16 @@ void NSSetMinimumSize(nsgadget *gadget,int width,int height){
 	[window setContentMinSize:rect.size];
 }
 
-void NSSetMaximumSize(nsgadget *gadget,int width,int height){
+void NSPeerSetMaximumSize(void *peer,int width,int height){
 	NSWindow	*window;
 	NSRect	rect;
 	int		style;
-	window=(NSWindow*)gadget->handle;
+	window=(NSWindow*)NSPeerNativeHandle(peer);
 	rect.origin.x=0;
 	rect.origin.y=0;
 	rect.size.width=width;
 	rect.size.height=height;
-	style=gadget->style;
+	style=NSPeerGadgetStyle(peer);
 	if (!(style&WINDOW_CLIENTCOORDS)){
 		rect=[window contentRectForFrameRect:rect];
 		rect.size.width-=rect.origin.x;
@@ -3162,51 +4884,53 @@ void NSSetMaximumSize(nsgadget *gadget,int width,int height){
 }
 
 
-void NSSetStatus(nsgadget *gadget,BBString *data,int pos){
+void NSPeerSetStatus(void *peer,BBString *data,int pos){
 	NSString			*text;
 	WindowView			*window;
 	ToolView			*toolview;
 
 	text=NSStringFromBBString(data);
-	if ((gadget->style&WINDOW_TOOL) == 0) {
-		window=(WindowView*)gadget->handle;
+	if ((NSPeerGadgetStyle(peer)&WINDOW_TOOL) == 0) {
+		window=(WindowView*)NSPeerNativeHandle(peer);
 		[window setStatus:text align:pos];
 	} else {
-		toolview =(ToolView*)gadget->handle;
+		toolview =(ToolView*)NSPeerNativeHandle(peer);
 		[toolview setStatus:text align:pos];
 	}
 }
 
-int NSClientWidth(nsgadget *gadget){
+int NSPeerClientWidth(void *peer,int fallbackWidth){
 	NSRect		frame;	
-	if (gadget->internalclass==GADGET_DESKTOP){
+	if (NSPeerGadgetClass(peer)==GADGET_DESKTOP){
 		frame=[[NSScreen deepestScreen] visibleFrame];
 		return frame.size.width;
 	}
-	if (!gadget->view) return gadget->w;
-	frame=[gadget->view frame]; 
+	NSView *view=NSPeerClientView(peer);
+	if (!view) return fallbackWidth;
+	frame=[view frame];
 	return frame.size.width;
 }
 
-int NSClientHeight(nsgadget *gadget){
+int NSPeerClientHeight(void *peer,int fallbackHeight){
 	NSRect		frame;
-	if (gadget->internalclass==GADGET_DESKTOP){
+	if (NSPeerGadgetClass(peer)==GADGET_DESKTOP){
 		frame=[[NSScreen deepestScreen] visibleFrame];
 		return frame.size.height;
 	}
-	if (!gadget->view) return gadget->h;
-	frame=[gadget->view frame]; 
+	NSView *view=NSPeerClientView(peer);
+	if (!view) return fallbackHeight;
+	frame=[view frame];
 	return frame.size.height;
 }
 
-void NSRedraw(nsgadget *gadget){
+static void NSPeerRedraw(void *peer){
 	NSView	*view;
 	
-	view=(NSView*)gadget->handle;
+	view=(NSView*)NSPeerNativeHandle(peer);
 	[view display];	//Can just call the display method
 }
 
-void NSActivate(nsgadget *gadget,int code){
+void NSPeerActivate(void *peer,int code){
 	NSWindow	*window;
 	NSView		*view;
 	NSRect		frame;
@@ -3217,20 +4941,21 @@ void NSActivate(nsgadget *gadget,int code){
 	NSTextField *textfield;
 	NSText *text;
 	NSComboBox *combo;
+	id handle=NSPeerNativeHandle(peer);
 
 // generic commands
 
 	switch (code){
 	case ACTIVATE_REDRAW:
-		NSRedraw(gadget);
+		NSPeerRedraw(peer);
 		return;
 	}
 	
 // gadget specific	
 
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_WINDOW:
-		window=(NSWindow*)gadget->handle;
+		window=(NSWindow*)handle;
 		switch (code){
 		case ACTIVATE_FOCUS:
 			if([window isVisible]) [window makeKeyAndOrderFront:NSApp];		
@@ -3242,24 +4967,24 @@ void NSActivate(nsgadget *gadget,int code){
 		case ACTIVATE_PASTE:
 			break;
 		case ACTIVATE_MINIMIZE:
-			NSShow(gadget,true);
+			NSPeerSetShown(peer,true);
 			[window miniaturize:window];
 			break;
 		case ACTIVATE_MAXIMIZE:
 			if ([window isMiniaturized]) [window deminiaturize:window];
 			if ([window isZoomed]==NO) [window performZoom:window];
-			NSShow(gadget,true);
+			NSPeerSetShown(peer,true);
 			break;
 		case ACTIVATE_RESTORE:
 			if ([window isMiniaturized]) [window deminiaturize:window];
 			if ([window isZoomed]) [window performZoom:window];
-			NSShow(gadget,true);
+			NSPeerSetShown(peer,true);
 			break;
 		}
 		break;
 
 	case GADGET_TEXTFIELD:
-		textfield=(NSTextField*)gadget->handle;
+		textfield=(NSTextField*)handle;
 		window=[textfield window];
 		if (window) 
 		switch (code){
@@ -3282,7 +5007,7 @@ void NSActivate(nsgadget *gadget,int code){
 		break;
 
 	case GADGET_TEXTAREA:
-		textview=(TextView*)gadget->handle;
+		textview=(TextView*)handle;
 		switch (code){
 		case ACTIVATE_FOCUS:
 			window=[textview window];
@@ -3304,7 +5029,7 @@ void NSActivate(nsgadget *gadget,int code){
 		break;
 
 	case GADGET_NODE:
-		node=(NodeItem*)gadget->handle;
+		node=(NodeItem*)handle;
 		treeview=[node getOwner];
 		switch (code){	
 		case ACTIVATE_SELECT:
@@ -3322,14 +5047,14 @@ void NSActivate(nsgadget *gadget,int code){
 	case GADGET_COMBOBOX:
 		switch (code){
 		case ACTIVATE_FOCUS:
-			combo=(NSComboBox*)gadget->handle;
+			combo=(NSComboBox*)handle;
 			[combo selectText:nil];
 			break;	
 		}
 		break;
 
 	case GADGET_HTMLVIEW:
-		browser=(HTMLView*)gadget->handle;
+		browser=(HTMLView*)handle;
 		switch(code){
 		case ACTIVATE_COPY:
 			[browser copy:browser];
@@ -3349,43 +5074,47 @@ void NSActivate(nsgadget *gadget,int code){
 	default:
 		switch (code){
 		case ACTIVATE_FOCUS:
-			window=[gadget->handle window];
-			if (window) [window makeFirstResponder:gadget->handle];
+			window=[handle window];
+			if (window) [window makeFirstResponder:handle];
 			break;
 		}
 	}
 }
 
-void NSRethink(nsgadget *gadget){
+void NSPeerRethink(void *peer,int x,int y,int width,int height){
 	NSView		*view;
+	NSWindow		*window;
 	NSRect		rect,vis;
 	TextView	*textview;
 	TabView		*tabber;
 	NSButton		*button;
-	NSControl 	*combobox;
+	NSComboBox 	*combobox;
 	int			shouldhide;
 	
-	view=(NSView*)gadget->handle;
-	rect=NSMakeRect(gadget->x,gadget->y,gadget->w,gadget->h);
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	view=(NSView*)NSPeerNativeHandle(peer);
+	rect=NSMakeRect(x,y,width,height);
 	
 	shouldhide = FALSE;
 	
-	switch(gadget->internalclass){
+	switch(gadgetClass){
 	case GADGET_WINDOW:
+		window=(NSWindow*)view;
 		vis=[[NSScreen deepestScreen] visibleFrame];
 		rect.origin.x+=vis.origin.x;
 		rect.origin.y=vis.origin.y+vis.size.height-rect.origin.y-rect.size.height;
-		if ((gadget->style&WINDOW_CLIENTCOORDS)!=0){
-			if (gadget->style&WINDOW_STATUS) {
+		if ((gadgetStyle&WINDOW_CLIENTCOORDS)!=0){
+			if (gadgetStyle&WINDOW_STATUS) {
 				rect.origin.y-=STATUSBARHEIGHT;		
 				rect.size.height+=STATUSBARHEIGHT;		
 			}
-			rect = [(NSWindow*)view frameRectForContentRect:rect];
+			rect = [window frameRectForContentRect:rect];
 		}
 		
-		if(![view isVisible]) shouldhide = TRUE;
-		[view setFrame:rect display:YES];
-		if(shouldhide) [view orderOut:view];
+		if(![window isVisible]) shouldhide = TRUE;
+		[window setFrame:rect display:YES];
+		if(shouldhide) [window orderOut:window];
 		return;
 	case GADGET_NODE:
 	case GADGET_MENUITEM:
@@ -3401,25 +5130,25 @@ void NSRethink(nsgadget *gadget){
 	case GADGET_BUTTON:
 		button=(NSButton*)view;
 		// Push Button Size Hack
-		if ((gadget->style&7)==0){
-			if (gadget->h > 30) {
-				[button setBezelStyle:NSRegularSquareBezelStyle];
+		if ((gadgetStyle&7)==0){
+			if (height > 30) {
+				[button setBezelStyle:NSBezelStyleRegularSquare];
 			} else {
-				if (gadget->h < 24) { 
-					[button setBezelStyle:NSShadowlessSquareBezelStyle];
+				if (height < 24) {
+					[button setBezelStyle:NSBezelStyleShadowlessSquare];
 				} else {
-					[button setBezelStyle:NSRoundedBezelStyle];
+					[button setBezelStyle:NSBezelStyleRounded];
 				}
 			}	
 		}
 		break;
 	case GADGET_SLIDER:
-		switch (gadget->style&12){
+		switch (gadgetStyle&12){
 			case SLIDER_SCROLLBAR:
-				if (gadget->style & SLIDER_HORIZONTAL)
-					rect.size.height = [NSScroller scrollerWidth];
+				if (gadgetStyle & SLIDER_HORIZONTAL)
+					rect.size.height = MaxGUIScrollerWidth();
 				else
-					rect.size.width = [NSScroller scrollerWidth];		
+					rect.size.width = MaxGUIScrollerWidth();
 				break;
 		}
 	}
@@ -3428,94 +5157,113 @@ void NSRethink(nsgadget *gadget){
 	[view setNeedsDisplay:YES];	
 }
 
-void NSRemoveColor(nsgadget *gadget){
-	switch (gadget->internalclass){
+void NSPeerRemoveColor(void *peer){
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	id handle=NSPeerNativeHandle(peer);
+	switch (gadgetClass){
 	case GADGET_BUTTON:
-		if ([[gadget->handle cell] respondsToSelector:@selector(setDrawsBackground)]){
-			[[gadget->handle cell] setDrawsBackground:false];
-		}
+		[[handle cell] setBackgroundColor:nil];
 		break;
 	case GADGET_WINDOW:
-		[gadget->handle setBackgroundColor:nil];
-		[gadget->handle display];
+		[handle setBackgroundColor:[NSColor windowBackgroundColor]];
+		[handle display];
 		break;
 	case GADGET_LABEL:
-		if((gadget->style&3)==LABEL_SEPARATOR) break;
+		if((gadgetStyle&3)==LABEL_SEPARATOR) break;
+		[handle setBackgroundColor:[NSColor textBackgroundColor]];
+		[handle setDrawsBackground:false];
+		break;
 	case GADGET_COMBOBOX:
 	case GADGET_TEXTFIELD:
-		[gadget->handle setDrawsBackground:false];
+		[handle setBackgroundColor:[NSColor textBackgroundColor]];
+		[handle setDrawsBackground:true];
 		break;
 	case GADGET_LISTBOX:
+		[(ListView*)handle setColor:[NSColor controlBackgroundColor]];
+		break;
 	case GADGET_TREEVIEW:
+		[(TreeView*)handle removeColor];
+		break;
 	case GADGET_PANEL:
+		[(PanelView*)handle setColor:nil];
+		break;
 	case GADGET_TEXTAREA:
-		[gadget->handle setColor:nil];
+		[(TextView*)handle setColor:nil];
 		break;	
 	}
 }
 
-void NSSetColor(nsgadget *gadget,int r,int g,int b){
+void NSPeerSetColor(void *peer,int r,int g,int b){
 	NSColor				*color;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	id handle=NSPeerNativeHandle(peer);
 
-	color=[NSColor colorWithDeviceRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:1.0];
+	color=MaxGUIRGBColor(r,g,b);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_BUTTON:
-		if ([[gadget->handle cell] respondsToSelector:@selector(setBackgroundColor)]) [[gadget->handle cell] setBackgroundColor:color];
+		if ([[handle cell] respondsToSelector:@selector(setBackgroundColor)]) [[handle cell] setBackgroundColor:color];
 		break;
 	case GADGET_COMBOBOX:
 	case GADGET_WINDOW:
-		[gadget->handle setBackgroundColor:color];
-		[gadget->handle display];
+		[handle setBackgroundColor:color];
+		[handle display];
 		break;
 	case GADGET_LABEL:
-		if((gadget->style&3)==LABEL_SEPARATOR) break;
-		[gadget->handle setDrawsBackground:YES];
+		if((gadgetStyle&3)==LABEL_SEPARATOR) break;
+		[handle setDrawsBackground:YES];
 	case GADGET_TEXTFIELD:
-		[gadget->handle setBackgroundColor:color];
+		[handle setBackgroundColor:color];
 		break;
 	case GADGET_LISTBOX:
-	case GADGET_TREEVIEW:
 	case GADGET_PANEL:
 	case GADGET_TEXTAREA:
-		[gadget->handle setColor:color];
+		[handle setColor:color];
 		break;	
+	case GADGET_TREEVIEW:
+		[(TreeView*)handle setExplicitColor:color appearance:MaxGUIAppearanceForRGBBackground(r,g,b)];
+		break;
 	}
 }
 
-void NSSetAlpha(nsgadget *gadget,float alpha){
+void NSPeerSetAlpha(void *peer,float alpha){
 	NSWindow	*window;
 	PanelView	*panel;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_WINDOW:
-		window=(NSWindow*)gadget->handle;
+		window=(NSWindow*)handle;
 		[window setAlphaValue:alpha];
 		break;		
 	case GADGET_PANEL:
-		panel=(PanelView*)gadget->handle;
+		panel=(PanelView*)handle;
 		[panel setAlpha:alpha];
 		break;	
 	}
 }
 
 BBString *NSGetUserName(){
-	return bbStringFromNSString(CSCopyUserName(true));
+	return bbStringFromNSString(NSUserName());
 }
 
 BBString *NSGetComputerName(){
-	return bbStringFromNSString(CSCopyMachineName());
+	NSString *name=[[NSHost currentHost] localizedName];
+	return bbStringFromNSString(name ? name : @"");
 }
 
-BBString *NSRun(nsgadget *gadget,BBString *text){
+BBString *NSPeerRun(void *peer,BBString *text){
 	HTMLView			*htmlview;
 	NSString			*script;
 	BBString			*result;
 
 	result=&bbEmptyString;
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_HTMLVIEW:
-		htmlview=(HTMLView*)gadget->handle;
+		htmlview=(HTMLView*)NSPeerNativeHandle(peer);
 		script=NSStringFromBBString(text);
 		script=[htmlview stringByEvaluatingJavaScriptFromString:script];
 		result=bbStringFromNSString(script);
@@ -3524,12 +5272,16 @@ BBString *NSRun(nsgadget *gadget,BBString *text){
 	return result;
 }
 
-void NSSetText(nsgadget *gadget,BBString *data){
+void NSPeerSetText(void *peer,BBString *data){
 	NSString				*text;
 	NSMutableDictionary	*textAttributes;
 	NSMutableParagraphStyle *parastyle;
 	NSAttributedString		*attribtext;
-	NSObject				*nsobject;
+	id					nsobject;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	NSColor *textColor=NSPeerTextColor(peer);
+	int fontStyle=NSPeerFontStyle(peer);
 	
 	attribtext = nil;
 	
@@ -3537,23 +5289,23 @@ void NSSetText(nsgadget *gadget,BBString *data){
 	
 	text = NSStringFromBBString(data);
 	
-	nsobject = (NSObject*)gadget->handle;
+	nsobject = (NSObject*)NSPeerNativeHandle(peer);
 	
 	//printf( "data->length: %d\n", data->length );fflush(stdout);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_TEXTAREA:
-		[nsobject setText:text];
+		[(TextView*)nsobject setText:text];
 		break;
 	case GADGET_HTMLVIEW:
-		[nsobject setAddress:text];
+		[(HTMLView*)nsobject setAddress:text];
 		break;
 	case GADGET_LABEL: /* BaH */
-		switch (gadget->style&3) {
+		switch (gadgetStyle&3) {
 		case LABEL_SEPARATOR:
 			return;
 		default:
-			[nsobject setStringValue:text];
+			[(NSTextField*)nsobject setStringValue:text];
 			return;
 		}
 		break;
@@ -3565,91 +5317,105 @@ void NSSetText(nsgadget *gadget,BBString *data){
 			textAttributes = [NSMutableDictionary dictionary];
 			
 			// Font
-			[textAttributes setObject: [nsobject font] forKey:NSFontAttributeName];
+			[textAttributes setObject:[(NSButton*)nsobject font] forKey:NSFontAttributeName];
 	
 	 		// Paragraph style
 			parastyle = [[NSMutableParagraphStyle alloc] init];
 			[parastyle setParagraphStyle:[NSParagraphStyle defaultParagraphStyle]];
 			
-			if(gadget->internalclass == GADGET_BUTTON){
-				if(((gadget->style & BUTTON_PUSH) == BUTTON_PUSH) ||
-				  (((gadget->style & 7) != BUTTON_RADIO) &&
-				   ((gadget->style & 7) != BUTTON_CHECKBOX)))
-					[parastyle setAlignment:NSCenterTextAlignment];
+			if(gadgetClass == GADGET_BUTTON){
+				if(((gadgetStyle & BUTTON_PUSH) == BUTTON_PUSH) ||
+				  (((gadgetStyle & 7) != BUTTON_RADIO) &&
+				   ((gadgetStyle & 7) != BUTTON_CHECKBOX)))
+					[parastyle setAlignment:NSTextAlignmentCenter];
 			}
 			
 			[textAttributes setObject: parastyle forKey:NSParagraphStyleAttributeName];
 			[parastyle release];
 			
 			// Text color
-			if(gadget->textcolor) [textAttributes setObject: gadget->textcolor forKey: NSForegroundColorAttributeName];
+			if(textColor) [textAttributes setObject:textColor forKey:NSForegroundColorAttributeName];
 			
 			// Underline / strikethrough
 			[textAttributes setObject: [NSNumber numberWithInt:0] forKey: NSUnderlineStyleAttributeName];
 			[textAttributes setObject: [NSNumber numberWithInt:0] forKey: NSStrikethroughStyleAttributeName];
 			
-			if ((gadget->intFontStyle&FONT_UNDERLINE)!=0) [textAttributes setObject: [NSNumber numberWithInt:(NSUnderlineStyleSingle|NSUnderlinePatternSolid)] forKey: NSUnderlineStyleAttributeName];
-			if ((gadget->intFontStyle&FONT_STRIKETHROUGH)!=0) [textAttributes setObject: [NSNumber numberWithInt:(NSUnderlineStyleSingle|NSUnderlinePatternSolid)] forKey: NSStrikethroughStyleAttributeName];
+			if ((fontStyle&FONT_UNDERLINE)!=0) [textAttributes setObject: [NSNumber numberWithInt:(NSUnderlineStyleSingle|NSUnderlinePatternSolid)] forKey: NSUnderlineStyleAttributeName];
+			if ((fontStyle&FONT_STRIKETHROUGH)!=0) [textAttributes setObject: [NSNumber numberWithInt:(NSUnderlineStyleSingle|NSUnderlinePatternSolid)] forKey: NSStrikethroughStyleAttributeName];
 			
 			// Create attibuted text
 			attribtext = [[NSAttributedString alloc] initWithString: text attributes: textAttributes];
 			
-			[nsobject setAttributedTitle:attribtext];
+			[(NSButton*)nsobject setAttributedTitle:attribtext];
+			[attribtext release];
 			break;
 		//}
 	case GADGET_MENUITEM:
-		[nsobject setTitle:text];
+		[(NSMenuItem*)nsobject setTitle:text];
 		// Required otherwise root window menus aren't updated.
-		[[nsobject submenu] setTitle:text];
+		[[(NSMenuItem*)nsobject submenu] setTitle:text];
+		MaxGUIReconcileMenuItemRole((NSMenuItem*)nsobject);
 		break;
 	case GADGET_PANEL:
+		[(PanelView*)nsobject setTitle:text];
+		break;
 	case GADGET_NODE:
+		[(NodeItem*)nsobject setTitle:text];
+		break;
 	case GADGET_WINDOW:
-		[nsobject setTitle:text];
+		[(NSWindow*)nsobject setTitle:text];
 		break;
 	case GADGET_COMBOBOX:
-		if(!(gadget->style & COMBOBOX_EDITABLE)) break;
+		if(!(gadgetStyle & COMBOBOX_EDITABLE)) break;
 	case GADGET_TEXTFIELD:
-		[nsobject setStringValue:text];
+		[(NSControl*)nsobject setStringValue:text];
 		break;
 	}
 }
 
-BBString *NSGetText(nsgadget *gadget){
+BBString *NSPeerGetText(void *peer){
 	
-	NSObject		*nsobject;
+	id			nsobject;
 	BBString		*result;
 
 	result=&bbEmptyString;
-	nsobject=(NSObject*)gadget->handle;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	nsobject=(NSObject*)NSPeerNativeHandle(peer);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_TEXTAREA:
-		result=bbStringFromNSString([[nsobject storage] string]);
+		result=bbStringFromNSString([[((TextView*)nsobject) storage] string]);
 		break;
 	case GADGET_TEXTFIELD:
 	case GADGET_COMBOBOX:
-		result=bbStringFromNSString([nsobject stringValue]);
+		result=bbStringFromNSString([(NSControl*)nsobject stringValue]);
 		break;	
 	case GADGET_HTMLVIEW:
-		result=bbStringFromNSString([nsobject address]);
+		result=bbStringFromNSString([(HTMLView*)nsobject address]);
 		break;
 	case GADGET_NODE:
-		result=bbStringFromNSString([nsobject value]);
+		result=bbStringFromNSString([(NodeItem*)nsobject value]);
 		break;
 	case GADGET_LABEL: /* BaH */
-		switch (gadget->style&3) {
+		switch (gadgetStyle&3) {
 		case 0:
 		case LABEL_FRAME:
 		case LABEL_SUNKENFRAME:
-			result=bbStringFromNSString([nsobject stringValue]);
+			result=bbStringFromNSString([(NSTextField*)nsobject stringValue]);
 		}
 		break;
 	case GADGET_PANEL:
+		result=bbStringFromNSString([(PanelView*)nsobject title]);
+		break;
 	case GADGET_WINDOW:
+		result=bbStringFromNSString([(NSWindow*)nsobject title]);
+		break;
 	case GADGET_BUTTON:
+		result=bbStringFromNSString([(NSButton*)nsobject title]);
+		break;
 	case GADGET_MENUITEM:
-		result=bbStringFromNSString([nsobject title]);
+		result=bbStringFromNSString([(NSMenuItem*)nsobject title]);
 		break;
 	}
 	return result;
@@ -3660,49 +5426,60 @@ int NSCharWidth(NSFont *font,int charcode){
 	return (int)size.width;
 }
 
-void NSSetFont(nsgadget *gadget,NSFont *font){
-	NSView			*view;
+void NSPeerSetFont(void *peer,NSFont *font,int fontStyle){
+	id			view;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
 	
-	view = (NSView*)gadget->handle;
+	NSPeerStoreFontStyle(peer,fontStyle);
+	view = (NSView*)NSPeerNativeHandle(peer);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 		case GADGET_LABEL:
-			if ((gadget->style&3)==LABEL_SEPARATOR) break;
+			if ((gadgetStyle&3)==LABEL_SEPARATOR) break;
 		case GADGET_BUTTON:
-			[view setFont:font];
-			NSSetText(gadget, NSGetText(gadget));		//Apply underline/strikethough formatting as attributed text in NSSetText().
+			[(NSControl*)view setFont:font];
+			NSPeerSetText(peer, NSPeerGetText(peer));		//Apply underline/strikethough formatting as attributed text.
 			break;
 		case GADGET_LISTBOX:
+			[(ListView*)view setFont:font];
+			break;
 		case GADGET_TREEVIEW:
+			[(TreeView*)view setFont:font];
+			break;
 		case GADGET_COMBOBOX:
-		case GADGET_TEXTAREA:
 		case GADGET_TEXTFIELD:
+			[(NSControl*)view setFont:font];
+			break;
+		case GADGET_TEXTAREA:
+			[(TextView*)view setFont:font];
+			break;
 		case GADGET_TABBER:
-			[view setFont:font];
+			[(NSTabView*)view setFont:font];
 			break;
 		
 	}
 }
 
-BBString * NSGetTooltip(nsgadget *gadget){
+BBString * NSPeerGetTooltip(void *peer){
 
 	BBString			*result;
 	NSView			*view;
 	
 	result=&bbEmptyString;
-	view=(NSView*)gadget->handle;
+	view=(NSView*)NSPeerNativeHandle(peer);
 	
 	if(view) result=bbStringFromNSString([view toolTip]);
 	
 	return result;
 }
 
-int NSSetTooltip(nsgadget *gadget,BBString *data){
+int NSPeerSetTooltip(void *peer,BBString *data){
 	
 	NSString			*text;
 	NSView			*view;
 	
-	view =(NSView*)gadget->handle;
+	view =(NSView*)NSPeerNativeHandle(peer);
 	text=NSStringFromBBString(data);
 	
 	if(view){
@@ -3715,132 +5492,135 @@ int NSSetTooltip(nsgadget *gadget,BBString *data){
 
 // gadgetitem commands
 
-void NSClearItems(nsgadget *gadget)
+void NSPeerClearItems(void *peer)
 {
 	ListView			*listbox;
-	NSControl 		*combo;
+	NSComboBox 		*combo;
 	NSTabView			*tabber;
 	Toolbar			*toolbar;
 	NSToolbarItem		*item;
 	NSArray			*items;
 	int				i,n;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 		
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
+		listbox=(ListView*)handle;
 		[listbox clear];
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		[combo removeAllItems];
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;
+		tabber=(NSTabView*)handle;
 		items=[tabber tabViewItems];
 		n=[tabber numberOfTabViewItems];
 		for (i=0;i<n;i++) [tabber removeTabViewItem:[tabber tabViewItemAtIndex:0]];
 		break;
 	case GADGET_TOOLBAR:
-		toolbar=(Toolbar*)gadget->handle;
+		toolbar=(Toolbar*)handle;
 		items=[toolbar items];
 		n=[items count];
-		for (i=0;i<n;i++) 	[toolbar removeItemAtIndex:0];
+		for (i=0;i<n;i++) {
+			[toolbar removeItemAtIndex:0];
+			[toolbar forgetToolbarItemAtIndex:0];
+		}
 		break;
 	}
 }
 
-void NSAddItem(nsgadget *gadget,int index,BBString *data,BBString *tip,NSImage *image,BBObject *extra){
+void NSPeerAddItem(void *peer,int index,BBString *data,BBString *tip,NSImage *image,BBObject *extra){
 	NSString			*text,*tiptext;
-	NSControl 		*combo;
+	NSComboBox 		*combo;
 	NSTabView			*tabber;
 	TabViewItem		*tabitem;
 	ListView			*listbox;
 	Toolbar			*toolbar;
 	NSToolbarItem		*item;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 
 	text=NSStringFromBBString(data);
 	tiptext=NSStringFromBBString(tip);
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
+		listbox=(ListView*)handle;
 		[listbox addItem:text atIndex:index withImage:image withTip:tiptext withExtra:extra];
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		[combo insertItemWithObjectValue:text atIndex:index];
 //		[[combo itemAtIndex:index] setImage:image];
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;	
+		tabber=(NSTabView*)handle;
 		tabitem=[[TabViewItem alloc] initWithIdentifier:text];
 		[tabitem setLabel:text];
 		[tabitem setImage:image];
+		[tabitem setToolTip:tiptext];
 		[tabber insertTabViewItem:tabitem atIndex:index];	
 		[tabitem release];
 		break;
 	case GADGET_TOOLBAR:	
-		toolbar=(Toolbar*)gadget->handle;
-		if (image==0){			
-			int v;
-			Gestalt( 'sysv',&v );
-			if( v>=0x1070 ){
-				[toolbar insertItemWithItemIdentifier:NSToolbarSpaceItemIdentifier atIndex:index];
-			}else{
-				[toolbar insertItemWithItemIdentifier:NSToolbarSeparatorItemIdentifier atIndex:index];
-			}
+		toolbar=(Toolbar*)handle;
+		if (image==0){
+			[toolbar registerStandardIdentifier:NSToolbarSpaceItemIdentifier atIndex:index];
+			[toolbar insertItemWithItemIdentifier:NSToolbarSpaceItemIdentifier atIndex:index];
 		}
 		else{
-			item=[[NSToolbarItem alloc] initWithItemIdentifier:text];
+			item=[[NSToolbarItem alloc] initWithItemIdentifier:[toolbar nextItemIdentifier]];
 			[item setImage:image];
 //			[item setLabel:text];
 			[item setAction:@selector(iconSelect:)];
 			[item setTarget:GlobalApp];
 			[item setToolTip:tiptext];
 			[item setTag:0];
-			[GlobalApp addToolbarItem:item];
-			[toolbar addToolbarItem:item];
-			[toolbar insertItemWithItemIdentifier:text atIndex:index];		
+			[toolbar registerToolbarItem:item atIndex:index];
+			[toolbar insertItemWithItemIdentifier:[item itemIdentifier] atIndex:index];
+			[item release];
 		}
 		break;
 	}
 }
 
-NSToolbarItem *FindToolbarItem(NSToolbar *toolbar,int index){
-	return (NSToolbarItem*)[[toolbar items] objectAtIndex:index];
-}
-
-void NSSetItem(nsgadget *gadget,int index,BBString *data,BBString *tip,NSImage *image,BBObject *extra){
+void NSPeerSetItem(void *peer,int index,BBString *data,BBString *tip,NSImage *image,BBObject *extra){
 	NSString			*text,*tiptext;
-	NSControl 		*combo;
+	NSComboBox 		*combo;
 	NSTabView			*tabber;
 	TabViewItem		*tabitem;
 	ListView			*listbox;
 	Toolbar			*toolbar;
 	NSToolbarItem		*item;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 
 	text=NSStringFromBBString(data);
 	tiptext=NSStringFromBBString(tip);
 
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
+		listbox=(ListView*)handle;
 		[listbox setItem:text atIndex:index withImage:image withTip:tiptext withExtra:extra];
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		[combo removeItemAtIndex:index];
 		[combo insertItemWithObjectValue:text atIndex:index];
 //		[[combo itemAtIndex:index] setImage:image];
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;
+		tabber=(NSTabView*)handle;
 		tabitem=(TabViewItem*)[tabber tabViewItemAtIndex:index];
 		[tabitem setLabel:text];
 		[tabitem setImage:image];
+		[tabitem setToolTip:tiptext];
+		[(TabView*)tabber synchronizeSegments];
 		break;
 	case GADGET_TOOLBAR:	
-		toolbar=(Toolbar*)gadget->handle;
-		item=FindToolbarItem(toolbar,index);
+		toolbar=(Toolbar*)handle;
+		item=[toolbar registeredToolbarItemAtIndex:index];
 		if (item)	{
 //			[item setLabel:text];
 			[item setImage:image];
@@ -3851,60 +5631,66 @@ void NSSetItem(nsgadget *gadget,int index,BBString *data,BBString *tip,NSImage *
 	}
 }
 
-void NSRemoveItem(nsgadget *gadget,int index){
+void NSPeerRemoveItem(void *peer,int index){
 	ListView		*listbox;
-	NSControl 	*combo;
+	NSComboBox 	*combo;
 	NSTabView		*tabber;
 	TabViewItem	*tabitem;
 	Toolbar		*toolbar;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
+		listbox=(ListView*)handle;
 		[listbox removeItemAtIndex:index];
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		[combo removeItemAtIndex:index];
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;
+		tabber=(NSTabView*)handle;
 		tabitem=(TabViewItem*)[tabber tabViewItemAtIndex:index];
 		[tabber removeTabViewItem:tabitem];
 		break;
 	case GADGET_TOOLBAR:
-		toolbar=(Toolbar*)gadget->handle;
+		toolbar=(Toolbar*)handle;
 		[toolbar removeItemAtIndex:(int)index];
+		[toolbar forgetToolbarItemAtIndex:index];
 		break;
 	}
 }
 
-void NSSelectItem(nsgadget *gadget,int index,int state){
-	NSControl 		*combo;
+void NSPeerSelectItem(void *peer,int index,int state){
+	NSComboBox 		*combo;
 	NSTabView			*tabber;
 	ListView			*listbox;
 	Toolbar			*toolbar;
 	NSToolbarItem		*item;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
+		listbox=(ListView*)handle;
 		if(state) [listbox selectItem:index]; else [listbox deselectItem:index];
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		[combo setDelegate:nil];
 		[combo selectItemAtIndex:index];
 		[combo setObjectValue:[combo objectValueOfSelectedItem]];
 		[combo setDelegate:GlobalApp];
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;
+		tabber=(NSTabView*)handle;
 		[tabber selectTabViewItemAtIndex:index];
 		break;
 	case GADGET_TOOLBAR:	
-		toolbar=(Toolbar*)gadget->handle;
-		item=FindToolbarItem(toolbar,index);
+		toolbar=(Toolbar*)handle;
+		item=[toolbar registeredToolbarItemAtIndex:index];
+		if (!item) break;
 		BOOL enable=(state&STATE_DISABLED)?false:true;
 		[item setEnabled:enable];
 		int pressed=(state&STATE_SELECTED)?1:0;
@@ -3913,31 +5699,34 @@ void NSSelectItem(nsgadget *gadget,int index,int state){
 	}
 }
 
-int NSSelectedItem(nsgadget *gadget,int index){
+int NSPeerSelectedItem(void *peer,int index){
 	NSComboBox		*combo;
 	NSTabView			*tabber;
 	ListView			*listbox;
 	Toolbar			*toolbar;
 	NSToolbarItem		*item;
 	int				state;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	id handle=NSPeerNativeHandle(peer);
 
 	state=0;
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LISTBOX:
-		listbox=(ListView*)gadget->handle;
-		if ([[listbox table] selectedRow]==index) state|=STATE_SELECTED;
+		listbox=(ListView*)handle;
+		if ([[[listbox table] selectedRowIndexes] containsIndex:index]) state|=STATE_SELECTED;
 		break;
 	case GADGET_COMBOBOX:
-		combo=(NSControl*)gadget->handle;
+		combo=(NSComboBox*)handle;
 		if ([combo indexOfSelectedItem]==index) state|=STATE_SELECTED;
 		break;
 	case GADGET_TABBER:
-		tabber=(NSTabView*)gadget->handle;
+		tabber=(NSTabView*)handle;
 		if ([tabber indexOfTabViewItem:[tabber selectedTabViewItem]]==index) state|=STATE_SELECTED;
 		break;
 	case GADGET_TOOLBAR:	
-		toolbar=(Toolbar*)gadget->handle;
-		item=FindToolbarItem(toolbar,index);
+		toolbar=(Toolbar*)handle;
+		item=[toolbar registeredToolbarItemAtIndex:index];
+		if (!item) break;
 		if (![item isEnabled]) state|=STATE_DISABLED;
 		if ([item tag]!=0) state|=STATE_SELECTED;
 		break;
@@ -3947,27 +5736,28 @@ int NSSelectedItem(nsgadget *gadget,int index){
 
 // treeview commands
 
-int NSCountKids(nsgadget *gadget){
+int NSPeerCountKids(void *peer){
 	TreeView		*treeview;
 	NodeItem		*node;
+	id handle=NSPeerNativeHandle(peer);
 
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_TREEVIEW:
-		treeview=(TreeView*)gadget->handle;
+		treeview=(TreeView*)handle;
 		return [treeview count];
 	case GADGET_NODE:
-		node=(NodeItem*)gadget->handle;
+		node=(NodeItem*)handle;
 		return [node count];
 	}
 	return 0;
 }
 
-id NSSelectedNode(nsgadget *gadget){
+id NSPeerSelectedNode(void *peer){
 	TreeView		*treeview;
 
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_TREEVIEW:
-		treeview=(TreeView*)gadget->handle;
+		treeview=(TreeView*)NSPeerNativeHandle(peer);
 		return [treeview selectedNode];		
 	}
 	return 0;
@@ -4024,7 +5814,7 @@ NSRange GetRange(NSTextStorage *storage,int pos,int count,int units){
 	
 }
 
-void NSReplaceText(nsgadget *gadget,int pos,int count,BBString *data,int units){
+void NSPeerReplaceText(void *peer,int pos,int count,BBString *data,int units){
 	NSString			*text;
 	TextView			*textarea;
 	NSRange			range,snap;
@@ -4032,7 +5822,8 @@ void NSReplaceText(nsgadget *gadget,int pos,int count,BBString *data,int units){
 	unsigned int			size;
 	
 	text=NSStringFromBBString(data);
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
+	[textarea beginProgrammaticChange];
 	
 	if(([[textarea string] length] == 0) || ((pos == 0) && (count == TEXTAREA_ALL))){
 		
@@ -4050,103 +5841,111 @@ void NSReplaceText(nsgadget *gadget,int pos,int count,BBString *data,int units){
 		[textarea setSelectedRange:snap];
 		
 	}
+	[textarea endProgrammaticChange];
 	
 }
 
-void NSAddText(nsgadget *gadget,BBString *data){
+void NSPeerAddText(void *peer,BBString *data){
 	NSString			*text;
 	TextView			*textarea;
 	NSRange			range;
 
 	text=NSStringFromBBString(data);
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
+	[textarea beginProgrammaticChange];
 	[textarea addText:text];
 	range=GetRange([textarea textStorage],[[textarea string] length],0,0);
 	[textarea setSelectedRange:range];
 	[textarea scrollRangeToVisible:range];
+	[textarea endProgrammaticChange];
 }
 
-BBString *NSAreaText(nsgadget *gadget,int pos,int length,int units){
+BBString *NSPeerAreaText(void *peer,int pos,int length,int units){
 	TextView			*textarea;
 	NSRange			range;
 	NSAttributedString	*astring;
 	BBString				*bstring;
 
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	range=GetRange([textarea storage],pos,length,units);
 	astring=[[textarea storage] attributedSubstringFromRange:range];	
 	bstring=bbStringFromNSString([astring string]);
 	return bstring;
 }
 
-int NSAreaLen(nsgadget *gadget,int units){
+int NSPeerAreaLen(void *peer,int units){
 	TextView			*textarea;
 	NSTextStorage		*storage;
 	unsigned			ulen;
 
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	storage=[textarea storage];
 	ulen=[storage length];
 	if (units==TEXTAREA_LINES) ulen=LinePos([storage string],ulen)+1;
 	return ulen;	
 }
 
-void NSSetSelection(nsgadget *gadget,int pos,int length,int units){
+void NSPeerSetSelection(void *peer,int pos,int length,int units){
 	TextView			*textarea;
 	NSRange			range;
 
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
+	[textarea beginProgrammaticChange];
 	range=GetRange([textarea textStorage],pos,length,units);
 	[textarea setSelectedRange:range];
 	if( !textarea->lockedNest ) [textarea scrollRangeToVisible:range];
+	[textarea endProgrammaticChange];
 }
 
-void NSLockText(nsgadget *gadget){
+void NSPeerLockText(void *peer){
 	TextView			*textarea;
 
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	
 	if( !textarea->lockedNest ){
-		textarea->lockedRange=[textarea rangeForUserTextChange];
+		textarea->lockedRange=[textarea selectedRange];
 		[textarea->storage beginEditing];
 	}
 
 	++textarea->lockedNest;
 }
 
-void NSUnlockText(nsgadget *gadget){
+void NSPeerUnlockText(void *peer){
 	TextView			*textarea;
 	
-	textarea=(TextView*)gadget->handle;
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	
+	if( textarea->lockedNest<=0 ) return;
 	--textarea->lockedNest;
 
 	if( !textarea->lockedNest ){
 		NSRange range=textarea->lockedRange;
 		[textarea->storage endEditing];
 		if( range.location+range.length>[textarea->storage length] ) range=NSMakeRange( 0,0 );
+		[textarea beginProgrammaticChange];
 		[textarea setSelectedRange:range];
+		[textarea endProgrammaticChange];
 	}
 }
 
-void NSSetTabs(nsgadget *gadget,int tabwidth){
+void NSPeerSetTabs(void *peer,int tabwidth){
 	TextView *textarea;
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	[textarea setTabs:tabwidth];
 }
 
-void NSSetMargins(nsgadget *gadget,int leftmargin){
+void NSPeerSetMargins(void *peer,int leftmargin){
 	TextView *textarea;
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	[textarea setMargins:leftmargin];
 }
 
-int NSCharAt(nsgadget *gadget,int line){
+int NSPeerCharAt(void *peer,int line){
 	TextView		*textarea;
 	NSString		*text;
 	int				n,i;
 
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	text=[[textarea storage] string];
 	n=[text length];i=0;
 	while (line){
@@ -4157,65 +5956,67 @@ int NSCharAt(nsgadget *gadget,int line){
 	return i;
 }
 
-int NSLineAt(nsgadget *gadget,int pos){
+int NSPeerLineAt(void *peer,int pos){
 	TextView			*textarea;
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	return LinePos([[textarea storage] string],pos);
 }
 
-int NSCharX(nsgadget *gadget,int pos){
-	unsigned int rectCount;
+int NSPeerCharX(void *peer,int pos){
+	NSUInteger rectCount;
 	NSRectArray rectArray;
-	TextView	*textarea = (TextView*)gadget->handle;
+	TextView	*textarea = (TextView*)NSPeerNativeHandle(peer);
 	NSRange range = GetRange([textarea textStorage],pos,0,TEXTAREA_CHARS);
 	rectArray = [[textarea layoutManager] rectArrayForCharacterRange:range withinSelectedCharacterRange:range inTextContainer: [textarea textContainer] rectCount:&rectCount];
 	if(rectCount > 0) return (int)(((NSRect)rectArray[0]).origin.x-([textarea visibleRect].origin.x-[textarea textContainerOrigin].x));
+	return 0;
 }
 
-int NSCharY(nsgadget *gadget,int pos){
-	unsigned int rectCount;
+int NSPeerCharY(void *peer,int pos){
+	NSUInteger rectCount;
 	NSRectArray rectArray;
-	TextView	*textarea = (TextView*)gadget->handle;
+	TextView	*textarea = (TextView*)NSPeerNativeHandle(peer);
 	NSRange range = GetRange([textarea textStorage],pos,0,TEXTAREA_CHARS);
 	rectArray = [[textarea layoutManager] rectArrayForCharacterRange:range withinSelectedCharacterRange:range inTextContainer: [textarea textContainer] rectCount:&rectCount];
 	if(rectCount > 0) return (int)(((NSRect)rectArray[0]).origin.y-([textarea visibleRect].origin.y-[textarea textContainerOrigin].y));
+	return 0;
 }
 
-int NSGetCursorPos(nsgadget *gadget,int units){
+int NSPeerGetCursorPos(void *peer,int units){
 	TextView			*textarea;
 	NSRange			range;
 
-	textarea=(TextView*)gadget->handle;	
-	range=[textarea rangeForUserTextChange];
-	if (range.location == NSNotFound) return 0; //KORIOLIS (avoids read-only text-area crash)
-	if (units==TEXTAREA_LINES) return NSLineAt(gadget,range.location);
+	textarea=(TextView*)NSPeerNativeHandle(peer);
+	range=[textarea selectedRange];
+	if (units==TEXTAREA_LINES) return NSPeerLineAt(peer,range.location);
 	return range.location;
 }
 
-int NSGetSelectionlength(nsgadget *gadget,int units){
+int NSPeerGetSelectionLength(void *peer,int units){
 	TextView			*textarea;
 	NSRange			range;
 
-	textarea=(TextView*)gadget->handle;	
-	range=[textarea rangeForUserTextChange];
-	if (range.location == NSNotFound) return 0; //KORIOLIS (avoids read-only text-area crash)
+	textarea=(TextView*)NSPeerNativeHandle(peer);
+	range=[textarea selectedRange];
 	if (range.length == 0) return 0;
 	if (units == TEXTAREA_LINES){
-		int l0=NSLineAt(gadget,range.location);
-		int l1=NSLineAt(gadget,range.location+range.length-1);
+		int l0=NSPeerLineAt(peer,range.location);
+		int l1=NSPeerLineAt(peer,range.location+range.length-1);
 		return (l1-l0+1);
 	}
 	return range.length;
 }
 
-void NSSetTextColor(nsgadget *gadget,int r,int g,int b){
+void NSPeerSetTextColor(void *peer,int r,int g,int b){
+	NSColor *textColor=MaxGUIRGBColor(r,g,b);
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	id handle=NSPeerNativeHandle(peer);
+	NSPeerStoreTextColor(peer,textColor);
 	
-	if(gadget->textcolor) [gadget->textcolor release];
-	gadget->textcolor = [[NSColor colorWithDeviceRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:1.0] retain];
-	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_LABEL:
-		switch (gadget->style&3) {
+		switch (gadgetStyle&3) {
 			case LABEL_SEPARATOR:
 				return;
 		}
@@ -4223,23 +6024,23 @@ void NSSetTextColor(nsgadget *gadget,int r,int g,int b){
 	case GADGET_LISTBOX:
 	case GADGET_TREEVIEW:
 	case GADGET_TEXTAREA:
-		[gadget->handle setTextColor:gadget->textcolor];
+		[handle setTextColor:textColor];
 		break;
 	default:
-		NSSetText(gadget, NSGetText(gadget));	//Attempt to reset text with NSAttributedString
+		NSPeerSetText(peer, NSPeerGetText(peer));	//Attempt to reset text with NSAttributedString
 		break;
 	}
 }
 
-void NSSetStyle(nsgadget *gadget,int r,int g,int b,int flags,int pos,int length,int units)	{
+void NSPeerSetStyle(void *peer,int r,int g,int b,int flags,int pos,int length,int units){
 	TextView			*textarea;
 	NSRange			_range;
 	NSColor				*color;
 	int traits = 0;
 
-	textarea=(TextView*)gadget->handle;	
+	textarea=(TextView*)NSPeerNativeHandle(peer);
 	_range=GetRange([textarea storage],pos,length,units);
-	color=[NSColor colorWithDeviceRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:1.0];
+	color=MaxGUIRGBColor(r,g,b);
 	
 	[[textarea storage] removeAttribute:NSLinkAttributeName range:_range];
 	[[textarea storage] addAttribute:NSForegroundColorAttributeName value:color range:_range];
@@ -4252,15 +6053,12 @@ void NSSetStyle(nsgadget *gadget,int r,int g,int b,int flags,int pos,int length,
 	[[textarea storage] applyFontTraits: traits range:_range];
 }
 
-void NSSetValue(nsgadget *gadget,float value){
+void NSPeerSetValue(void *peer,float value){
 	NSProgressIndicator	*progbar;
-	NSDate				*date;
-	NSValue				*info;
-	NSRunLoop			*runloop;
 	
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_PROGBAR:
-		progbar=(NSProgressIndicator*)gadget->handle;
+		progbar=(NSProgressIndicator*)NSPeerNativeHandle(peer);
 		[progbar setDoubleValue:value];
 		break;
 	}
@@ -4268,16 +6066,15 @@ void NSSetValue(nsgadget *gadget,float value){
 
 // slider / scrollbar
 
-void NSSetSlider(nsgadget *gadget,double value,double small,double big){
+void NSPeerSetSlider(void *peer,double value,double small,double big){
 	NSScroller		*scroller;
 	NSSlider			*slider;
 	NSStepper			*stepper;
-	NSRect			frame;
-	float			size;
+	id handle=NSPeerNativeHandle(peer);
 	
-	switch (gadget->style&12){
+	switch (NSPeerGadgetStyle(peer)&12){
 	case SLIDER_SCROLLBAR:
-		scroller=(NSScroller*)gadget->handle;
+		scroller=(NSScroller*)handle;
 		if(value > (big-small))
 			value = 1.0L;
 		else if(big-small)
@@ -4288,13 +6085,14 @@ void NSSetSlider(nsgadget *gadget,double value,double small,double big){
 		[scroller setDoubleValue:value];
 		break;
 	case SLIDER_TRACKBAR:
-		slider=(NSSlider*)gadget->handle;
+	case SLIDER_DIAL:
+		slider=(NSSlider*)handle;
 		[slider setMinValue:small];
 		[slider setMaxValue:big];
 		[slider setDoubleValue:value];
 		break;
 	case SLIDER_STEPPER:
-		stepper=(NSStepper*)gadget->handle;
+		stepper=(NSStepper*)handle;
 		[stepper setMinValue:small];
 		[stepper setMaxValue:big];
 		[stepper setDoubleValue:value];
@@ -4302,9 +6100,9 @@ void NSSetSlider(nsgadget *gadget,double value,double small,double big){
 	}
 }
 
-double NSGetSlider(nsgadget *gadget){
+double NSPeerGetSlider(void *peer){
 	NSControl	*control;
-	control = (NSControl*)gadget->handle;
+	control = (NSControl*)NSPeerNativeHandle(peer);
 	return [control doubleValue];
 }
 
@@ -4441,19 +6239,22 @@ NSImage *NSPixmapImage(bbpixmap *pix){
 	return image;
 }
 
-void NSSetImage(nsgadget *gadget,NSImage *image,int flags){
+void NSPeerSetImage(void *peer,NSImage *image,int flags){
 	PanelView *panel;
 	NSButton *button;
 	NSMenuItem *menu;
+	int gadgetClass=NSPeerGadgetClass(peer);
+	int gadgetStyle=NSPeerGadgetStyle(peer);
+	id handle=NSPeerNativeHandle(peer);
 	
-	switch (gadget->internalclass){
+	switch (gadgetClass){
 	case GADGET_PANEL:
-		panel=(PanelView*)gadget->handle;
+		panel=(PanelView*)handle;
 		[panel setImage:image withFlags:flags];
 		break;
 	case GADGET_BUTTON:
-		if ((flags & GADGETPIXMAP_ICON) && (gadget->style <= BUTTON_PUSH)){ 
-			button=(NSButton *)gadget->handle;
+		if ((flags & GADGETPIXMAP_ICON) && (gadgetStyle <= BUTTON_PUSH)){
+			button=(NSButton *)handle;
 			[button setImage:image];
 			if (flags & GADGETPIXMAP_NOTEXT) {
 				[button setImagePosition:NSImageOnly];
@@ -4464,28 +6265,28 @@ void NSSetImage(nsgadget *gadget,NSImage *image,int flags){
 		break; 
 	case GADGET_MENUITEM:
 		if (flags & GADGETPIXMAP_ICON){
-			menu=(NSMenuItem*)gadget->handle;
+			menu=(NSMenuItem*)handle;
 			[menu setImage:image];
 		}
 		break;
 	}
 }
 
-void NSSetIcon(nsgadget *gadget,NSImage *image){
+void NSPeerSetIcon(void *peer,NSImage *image){
 	NodeItem	*node;
 		
-	switch (gadget->internalclass){
+	switch (NSPeerGadgetClass(peer)){
 	case GADGET_NODE:
-		node=(NodeItem*)gadget->handle;
+		node=(NodeItem*)NSPeerNativeHandle(peer);
 		[node setIcon:image];
 		break;
 	}
 }
 
-void NSSetNextView(nsgadget *gadget,nsgadget *nextgadget){
+void NSPeerSetNextView(void *peer,void *nextPeer){
 	NSView		*view,*nextview;
-	view=(NSView*)gadget->handle;
-	nextview=(NSView*)nextgadget->handle;
+	view=(NSView*)NSPeerNativeHandle(peer);
+	nextview=(NSView*)NSPeerNativeHandle(nextPeer);
 	[view setNextKeyView:nextview];
 }
 
@@ -4523,19 +6324,19 @@ static int keyToChar( int key ){
 	return 0;
 }
 
-void NSSetHotKey(nsgadget *gadget,int key,int modifier){
+void NSPeerSetHotKey(void *peer,int key,int modifier){
 	int chr;
 	unichar uchar[1];
 	NSString *keyStr;
-	int modMask;
+	NSEventModifierFlags modMask;
 	NSMenuItem *menuItem;
-	if( gadget->internalclass!=GADGET_MENUITEM ) return;
+	if( NSPeerGadgetClass(peer)!=GADGET_MENUITEM ) return;
 	modMask=0;
-	if( modifier & 1 ) modMask|=NSShiftKeyMask;
-	if( modifier & 2 ) modMask|=NSControlKeyMask;
-	if( modifier & 4 ) modMask|=NSAlternateKeyMask;
-	if( modifier & 8 ) modMask|=NSCommandKeyMask;
-	menuItem=(NSMenuItem*)gadget->handle;
+	if( modifier & 1 ) modMask|=NSEventModifierFlagShift;
+	if( modifier & 2 ) modMask|=NSEventModifierFlagControl;
+	if( modifier & 4 ) modMask|=NSEventModifierFlagOption;
+	if( modifier & 8 ) modMask|=NSEventModifierFlagCommand;
+	menuItem=(NSMenuItem*)NSPeerNativeHandle(peer);
 	chr=keyToChar( key );
 	if( !chr ) {
 		[menuItem setKeyEquivalent:@""];

--- a/cocoamaxgui.mod/cocoa.peer.m
+++ b/cocoamaxgui.mod/cocoa.peer.m
@@ -1,0 +1,220 @@
+#import <Cocoa/Cocoa.h>
+
+/*
+ * Stable native identity for the Cocoa bridge.
+ *
+ * The BlitzMax adapter owns this peer and treats it as an opaque handle.
+ * nativeHandle and clientView are non-owning references whose lifetimes are
+ * managed by the widget-specific AppKit implementation in cocoa.macos.m. They
+ * are cleared before the peer is destroyed. Native code does not inspect the
+ * BlitzMax TNSGadget object layout.
+ */
+@interface BMXMaxGUIPeer : NSObject {
+	id nativeHandle;
+	NSView *clientView;
+	int gadgetClass;
+	int gadgetStyle;
+	BMXMaxGUIPeer *parentPeer;
+	NSColor *textColor;
+	int fontStyle;
+	BOOL valid;
+}
+
+- (id)initWithClass:(int)gadgetClassValue style:(int)gadgetStyleValue parentPeer:(BMXMaxGUIPeer *)parentPeerValue;
+- (void)setNativeHandle:(id)handle clientView:(NSView *)view;
+- (void)invalidate;
+- (id)nativeHandle;
+- (NSView *)clientView;
+- (int)gadgetClass;
+- (int)gadgetStyle;
+- (BMXMaxGUIPeer *)parentPeer;
+- (void)setTextColor:(NSColor *)color;
+- (NSColor *)textColor;
+- (void)setFontStyle:(int)style;
+- (int)fontStyle;
+- (BOOL)isValid;
+
+@end
+
+@implementation BMXMaxGUIPeer
+
+- (id)initWithClass:(int)gadgetClassValue style:(int)gadgetStyleValue parentPeer:(BMXMaxGUIPeer *)parentPeerValue {
+	self = [super init];
+	if (self) {
+		nativeHandle = nil;
+		clientView = nil;
+		gadgetClass = gadgetClassValue;
+		gadgetStyle = gadgetStyleValue;
+		parentPeer = [parentPeerValue retain];
+		textColor = nil;
+		fontStyle = 0;
+		valid = YES;
+	}
+	return self;
+}
+
+- (void)setNativeHandle:(id)handle clientView:(NSView *)view {
+	nativeHandle = handle;
+	clientView = view;
+}
+
+- (void)invalidate {
+	valid = NO;
+	nativeHandle = nil;
+	clientView = nil;
+	[parentPeer release];
+	parentPeer = nil;
+	[textColor release];
+	textColor = nil;
+}
+
+- (id)nativeHandle {
+	return valid ? nativeHandle : nil;
+}
+
+- (NSView *)clientView {
+	return valid ? clientView : nil;
+}
+
+- (int)gadgetClass {
+	return gadgetClass;
+}
+
+- (int)gadgetStyle {
+	return gadgetStyle;
+}
+
+- (BMXMaxGUIPeer *)parentPeer {
+	return valid && [parentPeer isValid] ? parentPeer : nil;
+}
+
+- (void)setTextColor:(NSColor *)color {
+	if (textColor == color) return;
+	[textColor release];
+	textColor = [color retain];
+}
+
+- (NSColor *)textColor {
+	return valid ? textColor : nil;
+}
+
+- (void)setFontStyle:(int)style {
+	fontStyle = style;
+}
+
+- (int)fontStyle {
+	return fontStyle;
+}
+
+- (BOOL)isValid {
+	return valid;
+}
+
+@end
+
+static NSMutableDictionary *BMXPeerByNativeAddress;
+
+static NSValue *BMXPointerKey(void *pointer) {
+	return [NSValue valueWithPointer:pointer];
+}
+
+static void BMXRegisterNativeAddress(void *address, BMXMaxGUIPeer *peer) {
+	if (!address) return;
+	if (!BMXPeerByNativeAddress) BMXPeerByNativeAddress = [[NSMutableDictionary alloc] init];
+	[BMXPeerByNativeAddress setObject:BMXPointerKey(peer) forKey:BMXPointerKey(address)];
+}
+
+static void BMXUnregisterNativeAddress(void *address, BMXMaxGUIPeer *peer) {
+	if (!address || !BMXPeerByNativeAddress) return;
+	NSValue *key = BMXPointerKey(address);
+	NSValue *registered = [BMXPeerByNativeAddress objectForKey:key];
+	if ([registered pointerValue] == peer) [BMXPeerByNativeAddress removeObjectForKey:key];
+}
+
+static void BMXMaxGUIRequireMainThread(void) {
+	if (![NSThread isMainThread]) {
+		[NSException raise:NSInternalInconsistencyException
+			format:@"MaxGUI Cocoa peers must be accessed on the main thread"];
+	}
+}
+
+void *NSPeerCreate(int gadgetClass, int gadgetStyle, void *parentPeer) {
+	BMXMaxGUIRequireMainThread();
+	return [[BMXMaxGUIPeer alloc] initWithClass:gadgetClass style:gadgetStyle parentPeer:(BMXMaxGUIPeer *)parentPeer];
+}
+
+void NSPeerSetNativeObjects(void *peerHandle, void *handle, void *view) {
+	BMXMaxGUIRequireMainThread();
+	BMXMaxGUIPeer *peer = (BMXMaxGUIPeer *)peerHandle;
+	BMXUnregisterNativeAddress([peer nativeHandle], peer);
+	BMXUnregisterNativeAddress([peer clientView], peer);
+	[peer setNativeHandle:(id)handle clientView:(NSView *)view];
+	BMXRegisterNativeAddress(handle, peer);
+	BMXRegisterNativeAddress(view, peer);
+}
+
+void NSPeerDestroy(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	BMXMaxGUIPeer *peer = (BMXMaxGUIPeer *)peerHandle;
+	if (!peer) return;
+	BMXUnregisterNativeAddress([peer nativeHandle], peer);
+	BMXUnregisterNativeAddress([peer clientView], peer);
+	[peer invalidate];
+	[peer release];
+}
+
+void *NSPeerForNativeHandle(void *handle) {
+	BMXMaxGUIRequireMainThread();
+	if (!handle || !BMXPeerByNativeAddress) return NULL;
+	return [[BMXPeerByNativeAddress objectForKey:BMXPointerKey(handle)] pointerValue];
+}
+
+int NSPeerGadgetClass(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle gadgetClass];
+}
+
+int NSPeerGadgetStyle(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle gadgetStyle];
+}
+
+void *NSPeerParent(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle parentPeer];
+}
+
+void NSPeerStoreTextColor(void *peerHandle, void *color) {
+	BMXMaxGUIRequireMainThread();
+	[(BMXMaxGUIPeer *)peerHandle setTextColor:(NSColor *)color];
+}
+
+void *NSPeerTextColor(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle textColor];
+}
+
+void NSPeerStoreFontStyle(void *peerHandle, int style) {
+	BMXMaxGUIRequireMainThread();
+	[(BMXMaxGUIPeer *)peerHandle setFontStyle:style];
+}
+
+int NSPeerFontStyle(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle fontStyle];
+}
+
+void *NSPeerNativeHandle(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle nativeHandle];
+}
+
+void *NSPeerClientView(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return [(BMXMaxGUIPeer *)peerHandle clientView];
+}
+
+int NSPeerIsValid(void *peerHandle) {
+	BMXMaxGUIRequireMainThread();
+	return peerHandle && [(BMXMaxGUIPeer *)peerHandle isValid];
+}

--- a/cocoamaxgui.mod/cocoagui.bmx
+++ b/cocoamaxgui.mod/cocoagui.bmx
@@ -5,6 +5,7 @@ Import Pub.MacOs
 Import brl.systemdefault
 
 Import "-framework WebKit"
+Import "cocoa.peer.m"
 Import "cocoa.macos.m"
 
 Extern
@@ -22,80 +23,84 @@ Extern
 	
 	Function NSCharWidth:Int(font:Byte Ptr,charcode:Int)
 	' create
-	Function NSInitGadget(gadget:TNSGadget)
+	Function NSPeerCreate:Byte Ptr(internalclass:Int,style:Int,parentPeer:Byte Ptr)
+	Function NSPeerInitializeGadget(peer:Byte Ptr,Text:String,x:Int Ptr,y:Int Ptr,w:Int Ptr,h:Int Ptr,groupPeer:Byte Ptr)
+	Function NSPeerFreeGadget(peer:Byte Ptr)
+	Function NSPeerDestroy(peer:Byte Ptr)
+	Function NSPeerNativeHandle:Byte Ptr(peer:Byte Ptr)
+	Function NSPeerClientView:Byte Ptr(peer:Byte Ptr)
+	Function NSPeerIsValid:Int(peer:Byte Ptr)
 	' generic
 	Function NSActiveGadget:Byte Ptr()
-	Function NSFreeGadget(gadget:TNSGadget)
-	Function NSClientWidth:Int(gadget:TNSGadget)
-	Function NSClientHeight:Int(gadget:TNSGadget)
-	Function NSRethink(gadget:TNSGadget)
-	Function NSRedraw(gadget:TNSGadget)
-	Function NSActivate(gadget:TNSGadget,code:Int)
-	Function NSState:Int(gadget:TNSGadget)
-	Function NSShow(gadget:TNSGadget,state:Int)
-	Function NSEnable(gadget:TNSGadget,state:Int)
-	Function NSCheck(gadget:TNSGadget,state:Int)
-	Function NSSetNextView(gadget:TNSGadget,nextgadget:TNSGadget)
-	Function NSSetHotKey(gadget:TNSGadget,hotkey:Int,modifier:Int)
-	Function NSSetTooltip:Int(gadget:TNSGadget,tip:String)
-	Function NSGetTooltip:String(gadget:TNSGadget)
+	Function NSPeerClientWidth:Int(peer:Byte Ptr,fallbackWidth:Int)
+	Function NSPeerClientHeight:Int(peer:Byte Ptr,fallbackHeight:Int)
+	Function NSPeerRethink(peer:Byte Ptr,x:Int,y:Int,w:Int,h:Int)
+	Function NSPeerActivate(peer:Byte Ptr,code:Int)
+	Function NSPeerState:Int(peer:Byte Ptr)
+	Function NSPeerSetShown(peer:Byte Ptr,state:Int)
+	Function NSPeerSetEnabled(peer:Byte Ptr,state:Int)
+	Function NSPeerSetChecked(peer:Byte Ptr,state:Int)
+	Function NSPeerSetNextView(peer:Byte Ptr,nextPeer:Byte Ptr)
+	Function NSPeerSetHotKey(peer:Byte Ptr,hotkey:Int,modifier:Int)
+	Function NSPeerSetTooltip:Int(peer:Byte Ptr,tip:String)
+	Function NSPeerGetTooltip:String(peer:Byte Ptr)
 	Function NSSuperview:Byte Ptr(view:Byte Ptr)
 	' window
-	Function NSSetStatus(gadget:TNSGadget,Text:String,pos:Int)
-	Function NSSetMinimumSize(gadget:TNSGadget,width:Int,height:Int)
-	Function NSSetMaximumSize(gadget:TNSGadget,width:Int,height:Int)
-	Function NSPopupMenu(gadget:TNSGadget,menu:TNSGadget)
+	Function NSPeerSetStatus(peer:Byte Ptr,Text:String,pos:Int)
+	Function NSPeerSetMinimumSize(peer:Byte Ptr,width:Int,height:Int)
+	Function NSPeerSetMaximumSize(peer:Byte Ptr,width:Int,height:Int)
+	Function NSPeerPopupMenu(peer:Byte Ptr,menuPeer:Byte Ptr)
 	' font
 	Function NSRequestFont:Byte Ptr(font:Byte Ptr)
 	Function NSLoadFont:Byte Ptr(name:String,size:Double,flags:Int)
 	Function NSGetDefaultFont:Byte Ptr()
-	Function NSSetFont(gadget:TNSGadget,font:Byte Ptr)
+	Function NSPeerSetFont(peer:Byte Ptr,font:Byte Ptr,fontStyle:Int)
 	Function NSFontName:String(font:Byte Ptr)
 	Function NSFontStyle:Int(font:Byte Ptr)
 	Function NSFontSize:Double(font:Byte Ptr)
 	' items
-	Function NSClearItems(gadget:TNSGadget)
-	Function NSAddItem(gadget:TNSGadget,index:Int,Text:String,tip:String,image:Byte Ptr,extra:Object)
-	Function NSSetItem(gadget:TNSGadget,index:Int,Text:String,tip:String,image:Byte Ptr,extra:Object)
-	Function NSRemoveItem(gadget:TNSGadget,index:Int)
-	Function NSSelectItem(gadget:TNSGadget,index:Int,state:Int)
-	Function NSSelectedItem:Int(gadget:TNSGadget,index:Int)
-	Function NSSelectedNode:Byte Ptr(gadget:TNSGadget)
+	Function NSPeerClearItems(peer:Byte Ptr)
+	Function NSPeerAddItem(peer:Byte Ptr,index:Int,Text:String,tip:String,image:Byte Ptr,extra:Object)
+	Function NSPeerSetItem(peer:Byte Ptr,index:Int,Text:String,tip:String,image:Byte Ptr,extra:Object)
+	Function NSPeerRemoveItem(peer:Byte Ptr,index:Int)
+	Function NSPeerSelectItem(peer:Byte Ptr,index:Int,state:Int)
+	Function NSPeerSelectedItem:Int(peer:Byte Ptr,index:Int)
+	Function NSPeerSelectedNode:Byte Ptr(peer:Byte Ptr)
 	' text
-	Function NSSetText(gadget:TNSGadget,Text:String)
-	Function NSGetText:String(gadget:TNSGadget)
-	Function NSReplaceText(gadget:TNSGadget,pos:Int,length:Int,Text:String,units:Int)
-	Function NSAddText(gadget:TNSGadget,Text:String)
-	Function NSAreaText:String(gadget:TNSGadget,pos:Int,length:Int,units:Int)
-	Function NSAreaLen:Int(gadget:TNSGadget,units:Int)
-	Function NSLockText(gadget:TNSGadget)
-	Function NSUnlockText(gadget:TNSGadget)
-	Function NSSetTabs(gadget:TNSGadget,tabwidth:Int)
-	Function NSSetMargins(gadget:TNSGadget,leftmargin:Int)
-	Function NSSetColor(gadget:TNSGadget,r:Int,g:Int,b:Int)
-	Function NSRemoveColor(gadget:TNSGadget)
-	Function NSSetAlpha(gadget:TNSGadget,alpha:Float)
-	Function NSSetTextColor(gadget:TNSGadget,r:Int,g:Int,b:Int)
-	Function NSGetCursorPos:Int(gadget:TNSGadget,units:Int)
-	Function NSGetSelectionlength:Int(gadget:TNSGadget,units:Int)
-	Function NSSetStyle(gadget:TNSGadget,r:Int,g:Int,b:Int,flags:Int,pos:Int,length:Int,units:Int)	
-	Function NSSetSelection(gadget:TNSGadget,pos:Int,length:Int,units:Int)
-	Function NSCharAt:Int(gadget:TNSGadget,line:Int)
-	Function NSLineAt:Int(gadget:TNSGadget,index:Int)
-	Function NSCharX:Int(gadget:TGadget,char:Int)
-	Function NSCharY:Int(gadget:TGadget,char:Int)
+	Function NSPeerSetText(peer:Byte Ptr,Text:String)
+	Function NSPeerGetText:String(peer:Byte Ptr)
+	Function NSPeerReplaceText(peer:Byte Ptr,pos:Int,length:Int,Text:String,units:Int)
+	Function NSPeerAddText(peer:Byte Ptr,Text:String)
+	Function NSPeerAreaText:String(peer:Byte Ptr,pos:Int,length:Int,units:Int)
+	Function NSPeerAreaLen:Int(peer:Byte Ptr,units:Int)
+	Function NSPeerLockText(peer:Byte Ptr)
+	Function NSPeerUnlockText(peer:Byte Ptr)
+	Function NSPeerSetTabs(peer:Byte Ptr,tabwidth:Int)
+	Function NSPeerSetMargins(peer:Byte Ptr,leftmargin:Int)
+	Function NSPeerSetColor(peer:Byte Ptr,r:Int,g:Int,b:Int)
+	Function NSPeerRemoveColor(peer:Byte Ptr)
+	Function NSPeerSetAlpha(peer:Byte Ptr,alpha:Float)
+	Function NSPeerSetTextColor(peer:Byte Ptr,r:Int,g:Int,b:Int)
+	Function NSPeerGetCursorPos:Int(peer:Byte Ptr,units:Int)
+	Function NSPeerGetSelectionLength:Int(peer:Byte Ptr,units:Int)
+	Function NSPeerSetStyle(peer:Byte Ptr,r:Int,g:Int,b:Int,flags:Int,pos:Int,length:Int,units:Int)
+	Function NSPeerSetSelection(peer:Byte Ptr,pos:Int,length:Int,units:Int)
+	Function NSPeerCharAt:Int(peer:Byte Ptr,line:Int)
+	Function NSPeerLineAt:Int(peer:Byte Ptr,index:Int)
+	Function NSPeerCharX:Int(peer:Byte Ptr,char:Int)
+	Function NSPeerCharY:Int(peer:Byte Ptr,char:Int)
 	' prop
-	Function NSSetValue(gadget:TNSGadget,value:Float)
+	Function NSPeerSetValue(peer:Byte Ptr,value:Float)
 	' slider
-	Function NSSetSlider(gadget:TNSGadget,value:Double,small:Double,big:Double)
-	Function NSGetSlider:Double(gadget:TNSGadget)
+	Function NSPeerSetSlider(peer:Byte Ptr,value:Double,small:Double,big:Double)
+	Function NSPeerGetSlider:Double(peer:Byte Ptr)
 	' images for panels and nodes
 	Function NSPixmapImage:Byte Ptr(image:TPixmap)
-	Function NSSetImage(gadget:TNSGadget,nsimage:Byte Ptr,flags:Int)
-	Function NSSetIcon(gadget:TNSGadget,nsimage:Byte Ptr)
-	Function NSCountKids:Int(gadget:TNSGadget)
+	Function NSPeerSetImage(peer:Byte Ptr,nsimage:Byte Ptr,flags:Int)
+	Function NSPeerSetIcon(peer:Byte Ptr,nsimage:Byte Ptr)
+	Function NSPeerCountKids:Int(peer:Byte Ptr)
 	' html
-	Function NSRun:String(gadget:TNSGadget,script:String)
+	Function NSPeerRun:String(peer:Byte Ptr,script:String)
 	' misc
 	Function NSRelease(nsobject:Byte Ptr)
 	' system
@@ -223,10 +228,12 @@ Type TCocoaMaxGUIDriver Extends TMaxGUIDriver
 End Type
 
 Function GadgetFromHandle:TNSGadget( handle:Byte Ptr )
+	If Not handle Then Return Null
 	Return TNSGadget( GadgetMap.ValueForKey( TPtrWrapper.Create(handle) ) )
 End Function
 
-Function EmitCocoaOSEvent( event:Byte Ptr,handle:Byte Ptr,gadget:Object = Null )
+Function EmitCocoaOSEvent( event:Byte Ptr,handle:Byte Ptr,view:Byte Ptr,gadget:Object = Null )
+	' Keep stable peer identity separate from the NSView BRL uses for coordinates.
 	Local owner:TGadget = TGadget(gadget)
 	If Not owner Then owner = GadgetFromHandle( handle )
 	If owner Then
@@ -234,16 +241,16 @@ Function EmitCocoaOSEvent( event:Byte Ptr,handle:Byte Ptr,gadget:Object = Null )
 			owner = owner.source
 		Wend
 	EndIf
-	bbSystemEmitOSEvent event,handle,owner
+	bbSystemEmitOSEvent event,view,owner
 End Function
 
-Function EmitCocoaMouseEvent:Int( event:Byte Ptr, handle:Byte Ptr )
+Function EmitCocoaMouseEvent:Int( event:Byte Ptr, handle:Byte Ptr, view:Byte Ptr )
 	Local gadget:TNSGadget
 '	While handle
 		gadget = GadgetFromHandle( handle )
 		If gadget Then
 			If (gadget.sensitivity & SENSITIZE_MOUSE) Then
-				EmitCocoaOSEvent( event, handle, gadget )
+				EmitCocoaOSEvent( event, handle, view, gadget )
 				Return 1
 			EndIf
 			Return 0
@@ -252,19 +259,58 @@ Function EmitCocoaMouseEvent:Int( event:Byte Ptr, handle:Byte Ptr )
 '	Wend
 End Function
 
-Function EmitCocoaKeyEvent:Int( event:Byte Ptr, handle:Byte Ptr )
+Function EmitCocoaKeyEvent:Int( event:Byte Ptr, handle:Byte Ptr, view:Byte Ptr )
 	Local gadget:TNSGadget
 	While handle
 		gadget = GadgetFromHandle( handle )
 		If gadget Then
 			If (gadget.sensitivity & SENSITIZE_KEYS) Then
-				EmitCocoaOSEvent( event, handle, gadget )
+				EmitCocoaOSEvent( event, handle, view, gadget )
 				Return 1
 			EndIf
 			Return 0
 		EndIf
 		handle = NSSuperview(handle)
 	Wend
+End Function
+
+Function PostCocoaTreeEvent(id:Int, treeHandle:Byte Ptr, nodeHandle:Byte Ptr, mods:Int, x:Int, y:Int)
+	DispatchGuiEvents()
+	Local tree:TNSGadget = GadgetFromHandle(treeHandle)
+	Local node:TNSGadget = GadgetFromHandle(nodeHandle)
+	If Not tree Or tree.internalclass <> GADGET_TREEVIEW Then Return
+	If node And node.internalclass <> GADGET_NODE Then node = Null
+	PostGuiEvent id, tree, 0, mods, x, y, node
+End Function
+
+Function PostCocoaTreeDragEvent:Int(treeHandle:Byte Ptr, nodeHandle:Byte Ptr, button:Int, mods:Int, x:Int, y:Int)
+	If button < MOUSE_LEFT Or button > MOUSE_MIDDLE Then Return False
+	Local tree:TNSGadget = GadgetFromHandle(treeHandle)
+	Local node:TNSGadget = GadgetFromHandle(nodeHandle)
+	If Not tree Or tree.internalclass <> GADGET_TREEVIEW Then Return False
+	If Not (tree.style & TREEVIEW_DRAGNDROP) Then Return False
+	If Not node Or node.internalclass <> GADGET_NODE Then Return False
+	TGadget.dragGadget[button - 1] = node
+	PostGuiEvent EVENT_GADGETDRAG, tree, button, mods, x, y, node
+	Return True
+End Function
+
+Function PostCocoaGadgetDropEvent:Int(targetHandle:Byte Ptr, button:Int, mods:Int, x:Int, y:Int)
+	If button < MOUSE_LEFT Or button > MOUSE_MIDDLE Then Return False
+	Local target:TNSGadget = GadgetFromHandle(targetHandle)
+	If Not target Then Return False
+	Local dragged:TGadget = TGadget.dragGadget[button - 1]
+	If Not dragged Then Return False
+	TGadget.dragGadget[button - 1] = Null
+	PostGuiEvent EVENT_GADGETDROP, target, button, mods, x, y, dragged
+	Return True
+End Function
+
+Function CancelCocoaGadgetDrag:Int(button:Int)
+	If button < MOUSE_LEFT Or button > MOUSE_MIDDLE Then Return False
+	If Not TGadget.dragGadget[button - 1] Then Return False
+	TGadget.dragGadget[button - 1] = Null
+	Return True
 End Function
 
 ?Not Ptr64
@@ -282,12 +328,6 @@ Function PostCocoaGuiEvent( id:Int,handle:Byte Ptr,data:Long,mods:Int,x:Int,y:In
 		gadget = GadgetFromHandle(handle)
 		
 		If gadget Then
-			
-			Select gadget.internalclass
-				Case GADGET_TREEVIEW
-					extra=GadgetFromHandle(Byte Ptr(data))
-					data = 0
-			EndSelect
 			
 			Select id
 				Case EVENT_WINDOWSIZE
@@ -373,7 +413,7 @@ Function FilterKeyDown:Int( handle:Byte Ptr,key:Int,mods:Int )
 	If handle
 		source=GadgetFromHandle(handle)
 	EndIf
-	If source And source.eventfilter<>Null
+	If source And source.eventfilter<>TGadget.NullEventFilter
 		Local event:TEvent=CreateEvent(EVENT_KEYDOWN,source,key,mods)
 		Return source.eventfilter(event,source.context)
 	EndIf
@@ -390,7 +430,7 @@ Function FilterChar:Int( handle:Byte Ptr,key:Int,mods:Int )
 	If handle
 		source=GadgetFromHandle(handle)
 	EndIf
-	If source And source.eventfilter<>Null 'Return source.charfilter(char,mods,source.context)
+	If source And source.eventfilter<>TGadget.NullEventFilter 'Return source.charfilter(char,mods,source.context)
 		Local event:TEvent=CreateEvent(EVENT_KEYCHAR,source,key,mods)
 		Return source.eventfilter(event,source.context)
 	EndIf
@@ -401,8 +441,8 @@ Type TNSGadget Extends TGadget
 	
 	Field internalclass:Int, origclass:Int	'internalclass: Class the Cocoa driver uses to draw the gadget, origclass: Expected class to be returned by Class() method
 	Field handle:Byte Ptr
-	Field view:Byte Ptr, textcolor:Byte Ptr	'view: NSView handle, textcolor: NSColor handle for Objective-C code
-	Field intFontStyle:Int	'Copy of font.style used by cocoa.macos.m to handle underlining/strikethrough etc. that isn't included in NSFont
+	Field view:Byte Ptr
+	Field peer:Byte Ptr
 	Field pixmap:TPixmap
 	Field icons:TCocoaIconStrip
 	Field small:Int, big:Int
@@ -430,13 +470,23 @@ Type TNSGadget Extends TGadget
 			gadget.forceDisable = Not (TNSGadget(group).enabled And Not TNSGadget(group).forceDisable)
 		EndIf
 		
-		NSInitGadget gadget
+		If internalclass=GADGET_CANVAS Or (internalclass=GADGET_PANEL And (style&PANEL_ACTIVE)) Then
+			gadget.sensitivity:|SENSITIZE_MOUSE|SENSITIZE_KEYS
+		EndIf
+
+		Local groupPeer:Byte Ptr
+		If TNSGadget(group) Then groupPeer = TNSGadget(group).peer
+		gadget.peer = NSPeerCreate(internalclass,style,groupPeer)
+		GadgetMap.Insert TPtrWrapper.Create(gadget.peer),gadget
+		NSPeerInitializeGadget gadget.peer,Text,Varptr gadget.xpos,Varptr gadget.ypos,Varptr gadget.width,Varptr gadget.height,groupPeer
+		gadget.handle = NSPeerNativeHandle(gadget.peer)
+		gadget.view = NSPeerClientView(gadget.peer)
 
 		If internalclass<>GADGET_TOOLBAR 'toolbars retain name to key insertgadgetitem
 			gadget.name = Null
 		EndIf
 		
-		GadgetMap.Insert TPtrWrapper.Create(gadget.handle),gadget
+		If gadget.handle Then GadgetMap.Insert TPtrWrapper.Create(gadget.handle),gadget
 		If gadget.view And gadget.handle <> gadget.view Then
 			GadgetMap.Insert TPtrWrapper.Create(gadget.view),gadget
 		EndIf
@@ -495,8 +545,8 @@ Type TNSGadget Extends TGadget
 			If prev Exit
 		Next
 		If Not prev Return
-		NSSetNextView(prev,Self)
-		NSSetNextView(Self,First)
+		NSPeerSetNextView(prev.peer,peer)
+		NSPeerSetNextView(peer,First.peer)
 	End Method
 	
 	Method Delete()
@@ -508,59 +558,66 @@ Type TNSGadget Extends TGadget
 	Method Query:Byte Ptr(queryid:Int)
 		Select queryid
 			Case QUERY_NSVIEW
+				If peer And NSPeerIsValid(peer) Then Return NSPeerNativeHandle(peer)
 				Return handle
 			Case QUERY_NSVIEW_CLIENT
+				If peer And NSPeerIsValid(peer) Then Return NSPeerClientView(peer)
 				Return view
 		End Select				
 	End Method
 
 	Method Free:Int()
-		If handle Then
+		If handle Or peer Then
 			
 			If canvas Then canvas.close
 			
-			GadgetMap.Remove TPtrWrapper.Create(handle)
+			If handle Then GadgetMap.Remove TPtrWrapper.Create(handle)
+			If peer Then GadgetMap.Remove TPtrWrapper.Create(peer)
 			If view And handle <> view Then
 				GadgetMap.Remove TPtrWrapper.Create(view)
-				view = Null
 			EndIf
 				
 			If parent Then
 				parent.kids.Remove Self
 			End If
 			
-			NSFreeGadget Self
+			If peer Then
+				NSPeerFreeGadget peer
+				NSPeerDestroy peer
+				peer = Null
+			EndIf
 			font = Null
 			
 			handle = Null
+			view = Null
 			
 		EndIf
 	End Method
 
 	Method Rethink:Int()			'resize	- was recursive
-		NSRethink( Self )
+		NSPeerRethink peer,xpos,ypos,width,height
 	End Method
 		
 	Method ClientWidth:Int()
-		Return Max(NSClientWidth(Self),0)
+		Return Max(NSPeerClientWidth(peer,width),0)
 	End Method
 	
 	Method ClientHeight:Int()
-		Return Max(NSClientHeight(Self),0)
+		Return Max(NSPeerClientHeight(peer,height),0)
 	End Method
 	
 	Method Activate:Int(cmd:Int)
-		NSActivate( Self, cmd )
+		NSPeerActivate peer,cmd
 	End Method
 	
 	Method State:Int()
-		Local tmpState:Int = NSState(Self)&~STATE_DISABLED
+		Local tmpState:Int = NSPeerState(peer)&~STATE_DISABLED
 		If Not enabled Then tmpState:|STATE_DISABLED
 		Return tmpState
 	End Method
 	
 	Method SetShow:Int(bool:Int)
-		NSShow( Self, bool )
+		NSPeerSetShown peer,bool
 	End Method
 
 	Method SetText:Int(msg:String)
@@ -580,38 +637,37 @@ Type TNSGadget Extends TGadget
 		ElseIf internalclass=GADGET_MENUITEM
 			msg=msg.Replace("&", "")
 		EndIf
-		NSSetText Self,msg
+		NSPeerSetText peer,msg
 	End Method
 	
 	Method Run:String(msg:String)
-		If internalclass=GADGET_HTMLVIEW Return NSRun(Self,msg)
+		If internalclass=GADGET_HTMLVIEW Return NSPeerRun(peer,msg)
 	End Method
 
 	Method GetText:String()
-		Return NSGetText(Self)
+		Return NSPeerGetText(peer)
 	End Method
 
 	Method SetFont:Int(pFont:TGuiFont)
 		If Not TCocoaGuiFont(pFont) Then pFont = TCocoaMaxGUIDriver.CocoaGuiFont
 		font = TCocoaGuiFont(pFont)
-		intFontStyle = font.style
-		NSSetFont( Self, font.handle )
+		NSPeerSetFont peer,font.handle,font.style
 	End Method
 
 	Method SetColor:Int(r:Int,g:Int,b:Int)
-		NSSetColor Self,r,g,b
+		NSPeerSetColor peer,r,g,b
 	End Method
 
 	Method RemoveColor:Int()
-		NSRemoveColor Self
+		NSPeerRemoveColor peer
 	End Method
 
 	Method SetAlpha:Int(alpha:Float)
-		NSSetAlpha Self,alpha
+		NSPeerSetAlpha peer,alpha
 	End Method
 	
 	Method SetTextColor:Int(r:Int,g:Int,b:Int)
-		NSSetTextColor Self,r,g,b
+		NSPeerSetTextColor peer,r,g,b
 	End Method
 	
 	Method SetPixmap:Int(pixmap:TPixmap,flags:Int)
@@ -634,33 +690,33 @@ Type TNSGadget Extends TGadget
 			EndIf
 			nsimage=NSPixmapImage(pixmap)
 		EndIf
-		NSSetImage(Self,nsimage,flags)
+		NSPeerSetImage peer,nsimage,flags
 	End Method
 	
 	Method SetTooltip:Int(pTip:String)
 		Select internalclass
 			Case GADGET_WINDOW, GADGET_DESKTOP, GADGET_LISTBOX, GADGET_MENUITEM, GADGET_TOOLBAR, GADGET_TABBER, GADGET_NODE
-			Default;Return NSSetTooltip( Self, pTip )
+			Default;Return NSPeerSetTooltip(peer,pTip)
 		EndSelect
 	EndMethod
 	
 	Method GetTooltip:String()
 		Select internalclass
 			Case GADGET_WINDOW, GADGET_DESKTOP, GADGET_LISTBOX, GADGET_MENUITEM, GADGET_TOOLBAR, GADGET_TABBER, GADGET_NODE
-			Default;Return NSGetTooltip( Self )
+			Default;Return NSPeerGetTooltip(peer)
 		EndSelect
 	EndMethod
 	
 	Method ExcludeOthers()
 		For Local g:TNSGadget = EachIn parent.kids
 			If g<>Self And g.internalclass=GADGET_BUTTON And (g.style&7)=BUTTON_RADIO
-				NSCheck g,False
+				NSPeerSetChecked g.peer,False
 			EndIf
 		Next
 	End Method
 
 	Method SetSelected:Int(bool:Int)
-		NSCheck Self,bool
+		NSPeerSetChecked peer,bool
 		If internalclass=GADGET_BUTTON And (style&7)=BUTTON_RADIO And bool
 			ExcludeOthers
 		EndIf
@@ -670,10 +726,10 @@ Type TNSGadget Extends TGadget
 		Local old:Int = enabled And Not forceDisable
 		enabled = enable
 		If Class() = GADGET_WINDOW Then
-			NSEnable Self, enable
+			NSPeerSetEnabled peer,enable
 		Else
 			enable = enable And Not forceDisable
-			NSEnable Self, enable
+			NSPeerSetEnabled peer,enable
 			If (enable <> old) Then
 				For Local tmpGadget:TNSGadget = EachIn kids
 					tmpGadget.forceDisable = Not enable
@@ -684,7 +740,7 @@ Type TNSGadget Extends TGadget
 	End Method
 	
 	Method SetHotKey:Int(hotkey:Int,modifier:Int)
-		NSSetHotKey Self,hotkey,modifier
+		NSPeerSetHotKey peer,hotkey,modifier
 	End Method
 	
 ' window commands
@@ -701,9 +757,9 @@ Type TNSGadget Extends TGadget
 		m0=msg
 		t=m0.find("~t");If t<>-1 m1=m0[t+1..];m0=m0[..t];
 		t=m1.find("~t");If t<>-1 m2=m1[t+1..];m1=m1[..t];		
-		NSSetStatus Self,m0,0
-		NSSetStatus Self,m1,1
-		NSSetStatus Self,m2,2
+		NSPeerSetStatus peer,m0,0
+		NSPeerSetStatus peer,m1,1
+		NSPeerSetStatus peer,m2,2
 	End Method
 	
 	Method GetMenu:TGadget()
@@ -714,18 +770,18 @@ Type TNSGadget Extends TGadget
 	
 	Method PopupMenu:Int(menu:TGadget,extra:Object)
 		popupextra=extra
-		NSPopupMenu Self,TNSGadget(menu)
+		NSPeerPopupMenu peer,TNSGadget(menu).peer
 	End Method
 	
 	Method UpdateMenu:Int()
 	End Method
 	
 	Method SetMinimumSize:Int(w:Int,h:Int)
-		NSSetMinimumSize Self,w,h
+		NSPeerSetMinimumSize peer,w,h
 	End Method
 	
 	Method SetMaximumSizeL:Int(w:Int,h:Int)
-		NSSetMaximumSize Self,w,h
+		NSPeerSetMaximumSize peer,w,h
 	End Method
 
 	Method SetIconStrip:Int(iconstrip:TIconStrip)
@@ -735,7 +791,7 @@ Type TNSGadget Extends TGadget
 ' item handling commands
 
 	Method ClearListItems:Int()
-		NSClearItems Self
+		NSPeerClearItems peer
 	End Method
 
 	Method InsertListItem:Int(index:Int,item:String,tip:String,icon:Int,extra:Object)
@@ -744,7 +800,7 @@ Type TNSGadget Extends TGadget
 			item=name+":"+index
 		EndIf
 		If icons And icon>=0 image=icons.images[icon]
-		NSAddItem Self,index,item,tip,image,extra
+		NSPeerAddItem peer,index,item,tip,image,extra
 	End Method
 	
 	Method SetListItem:Int(index:Int,item:String,tip:String,icon:Int,extra:Object)
@@ -753,19 +809,19 @@ Type TNSGadget Extends TGadget
 			item=name+":"+index
 		EndIf
 		If icons And icon>=0 image=icons.images[icon]
-		NSSetItem Self,index,item,tip,image,extra
+		NSPeerSetItem peer,index,item,tip,image,extra
 	End Method
 	
 	Method RemoveListItem:Int(index:Int)
-		NSRemoveItem Self,index
+		NSPeerRemoveItem peer,index
 	End Method
 	
 	Method SetListItemState:Int(index:Int,state:Int)
-		NSSelectItem Self,index,state
+		NSPeerSelectItem peer,index,state
 	End Method
 	
 	Method ListItemState:Int(index:Int)
- 		Return NSSelectedItem(Self,index)
+		Return NSPeerSelectedItem(peer,index)
 	End Method
 	
 ' treeview commands	
@@ -783,9 +839,9 @@ Type TNSGadget Extends TGadget
 		Wend
 		If p
 			If icon>-1
-				NSSetIcon Self,p.icons.images[icon]		
+				NSPeerSetIcon peer,p.icons.images[icon]
 			Else
-				NSSetIcon Self,Null		
+				NSPeerSetIcon peer,Null
 			EndIf
 		EndIf				
 	End Method
@@ -798,17 +854,17 @@ Type TNSGadget Extends TGadget
 	End Method
 	
 	Method ModifyNode:Int(Text:String,icon:Int)
-		NSSetText Self,Text
+		NSPeerSetText peer,Text
 		SetIcon icon
 	End Method
 
 	Method SelectedNode:TGadget()
-		Local	index:Byte Ptr = NSSelectedNode(Self)
+		Local	index:Byte Ptr = NSPeerSelectedNode(peer)
 		If (index) Return GadgetFromHandle(index)
 	End Method
 
 	Method CountKids:Int()
-		Return NSCountKids(Self)
+		Return NSPeerCountKids(peer)
 	End Method
 
 ' textarea commands
@@ -817,88 +873,88 @@ Type TNSGadget Extends TGadget
 ?debug
 		If pos<0 Or pos+length>AreaLen(units) Throw "Illegal Range"
 ?	
-		NSReplaceText Self,pos,length,Text$,units
+		NSPeerReplaceText peer,pos,length,Text$,units
 	End Method
 
 	Method AddText:Int(Text:String)
-		NSAddText Self,Text
+		NSPeerAddText peer,Text
 	End Method
 
 	Method AreaText:String(pos:Int,length:Int,units:Int)
 ?debug
 		If pos<0 Or pos+length>AreaLen(units) Throw "Illegal Range"
 ?	
-		Return NSAreaText(Self,pos,length,units)
+		Return NSPeerAreaText(peer,pos,length,units)
 	End Method
 
 	Method AreaLen:Int(units:Int)
-		Return NSAreaLen(Self,units)
+		Return NSPeerAreaLen(peer,units)
 	End Method
 
 	Method LockText:Int()
-		NSLockText Self
+		NSPeerLockText peer
 	End Method
 
 	Method UnlockText:Int()
-		NSUnlockText Self
+		NSPeerUnlockText peer
 	End Method
 
 	Method SetTabs:Int(tabwidth:Int)
-		NSSetTabs Self,tabwidth
+		NSPeerSetTabs peer,tabwidth
 	End Method
 
 	Method SetMargins:Int(leftmargin:Int)
-		NSSetMargins Self,leftmargin
+		NSPeerSetMargins peer,leftmargin
 	End Method
 
 	Method GetCursorPos:Int(units:Int)
-		Return NSGetCursorPos(Self,units)
+		Return NSPeerGetCursorPos(peer,units)
 	End Method
 
 	Method GetSelectionLength:Int(units:Int)
-		Return NSGetSelectionLength(Self,units)
+		Return NSPeerGetSelectionLength(peer,units)
 	End Method
 
 	Method SetStyle:Int(r:Int,g:Int,b:Int,flags:Int,pos:Int,length:Int,units:Int) 	
 ?debug
 		If pos<0 Or pos+length>AreaLen(units) Throw "Illegal Range"
 ?	
-		If length NSSetStyle Self,r,g,b,flags,pos,length,units
+		If length NSPeerSetStyle peer,r,g,b,flags,pos,length,units
 	End Method
 
 	Method SetSelection:Int(pos:Int,length:Int,units:Int)
 ?debug
 		If pos<0 Or pos+length>AreaLen(units) Throw "Illegal Range"
 ?	
-		NSSetSelection Self,pos,length,units
+		NSPeerSetSelection peer,pos,length,units
 	End Method
 
 	Method CharAt:Int(line:Int)
 ?debug
 		If line<0 Or line>AreaLen(TEXTAREA_LINES) Throw "Parameter Out Of Range"
 ?	
-		Return NSCharAt(Self,line)
+		Return NSPeerCharAt(peer,line)
 	End Method
 
 	Method LineAt:Int(index:Int)
 ?debug
 		If index<0 Or index>AreaLen(TEXTAREA_CHARS) Throw "Parameter Out Of Range"
 ?	
-		Return NSLineAt(Self,index)
+		Return NSPeerLineAt(peer,index)
 	End Method
 	
 	Method CharX:Int(char:Int)
-		Return NSCharX(Self,char)
+		Return NSPeerCharX(peer,char)
 	EndMethod
 	
 	Method CharY:Int(char:Int)
-		Return NSCharY(Self,char)
+		Return NSPeerCharY(peer,char)
 	EndMethod
 	
 ' progbar
 	
 	Method SetValue:Int(value:Float)
-		NSSetValue Self,value
+		NSPeerSetValue peer,value
 	End Method
 
 ' slider / scrollbar
@@ -906,15 +962,15 @@ Type TNSGadget Extends TGadget
 	Method SetRange:Int(_small:Int,_big:Int)
 		small=_small
 		big=_big
-		NSSetSlider Self,GetProp(),small,big
+		NSPeerSetSlider peer,GetProp(),small,big
 	End Method
 	
 	Method SetProp:Int(pos:Int)
-		NSSetSlider Self,pos,small,big
+		NSPeerSetSlider peer,pos,small,big
 	End Method
 
 	Method GetProp:Int()
-		Local value:Double = NSGetSlider(Self)
+		Local value:Double = NSPeerGetSlider(peer)
 		If Not (style&(SLIDER_TRACKBAR|SLIDER_STEPPER))
 			value:*(big-small)
 			If value>big-small value=big-small
@@ -925,7 +981,9 @@ Type TNSGadget Extends TGadget
 ' canvas
 
 	Method AttachGraphics:TGraphics( flags:Long )
+		If Not GetGraphicsDriver() Then Return Null
 		canvas=brl.Graphics.AttachGraphics( Query(QUERY_NSVIEW_CLIENT),flags )
+		Return canvas
 	End Method
 	
 	Method CanvasGraphics:TGraphics()

--- a/gtk3maxgui.mod/gtkgadget.bmx
+++ b/gtk3maxgui.mod/gtkgadget.bmx
@@ -2163,7 +2163,7 @@ Type TGTKEditable Extends TGTKGadget
 		Local source:TGTKEditable = TGTKEditable(obj)
 
 		' only if we are using a filter...
-		If source And source.eventfilter <> Null Then
+		If source And source.eventfilter <> TGadget.NullEventFilter Then
 			Local _key:Int, _mods:Int
 			bmx_gtk3maxgui_gdkeventkey(gdkEvent, Varptr _key, Varptr _mods)
 			Local key:Int = TGTKKeyMap.mapBack(_key)

--- a/maxgui.mod/gadget.bmx
+++ b/maxgui.mod/gadget.bmx
@@ -173,8 +173,6 @@ Const EVENT_GADGETDRAG% = $200A, EVENT_GADGETDROP% = $200B
 TEvent.RegisterId EVENT_GADGETDRAG, "GadgetDrag"
 TEvent.RegisterId EVENT_GADGETDROP, "GadgetDrop"
 
-' WARNING - struct nsgadget in brl.mod/cocoagui.mod/cocoa.macos.m must be modified if TGadget field count changes
-
 Type TGadget
 ' event propagation
 	Field	source:TGadget
@@ -193,6 +191,7 @@ Type TGadget
 ' filters
 	Field	eventfilter(event:TEvent,context:Object)
 	Field	context:Object
+	Global NullEventFilter(event:TEvent,context:Object)
 ' items
 	Field	items:TGadgetItem[]
 

--- a/maxguitextareascintilla.mod/win32.bmx
+++ b/maxguitextareascintilla.mod/win32.bmx
@@ -73,7 +73,7 @@ Type TWindowsScintillaTextArea Extends TWindowsTextArea
 			'Case WM_MOUSEWHEEL
 			'	If (Long(wp)&MK_CONTROL) Then SendMessageW _hwnd, EM_SETZOOM, 0, 0
 			Case WM_KEYDOWN
-				If eventfilter<>Null
+				If eventfilter<>TGadget.NullEventFilter
 					event=CreateEvent(EVENT_KEYDOWN,Self,Int(wp),keymods())
 					If Not eventfilter(event,context) Return True
 				EndIf
@@ -86,7 +86,7 @@ Type TWindowsScintillaTextArea Extends TWindowsTextArea
 				If (mods & MODIFIER_CONTROL And Not (mods & MODIFIER_OPTION)) Then
 					Return 1
 				End If
-				If eventfilter<>Null
+				If eventfilter<>TGadget.NullEventFilter
 					event=CreateEvent(EVENT_KEYCHAR,Self,Int(wp),mods)
 					If Not eventfilter(event,context) Return True
 				EndIf

--- a/win32maxguiex.mod/win32maxguiex.bmx
+++ b/win32maxguiex.mod/win32maxguiex.bmx
@@ -2921,8 +2921,11 @@ Type TWindowsListBox Extends TWindowsGadget
 				index=bmx_win32_NMITEMACTIVATE_iItem(nmhdrPtr)
 				Local item:TGadgetItem
 				If index>=0 And index<items.length
+					Local point[2]
+					GetCursorPos_ point
+					ScreenToClient _hwnd, point
 					item=items[index]
-					PostGuiEvent EVENT_GADGETMENU,index,0,0,0,item.extra
+					PostGuiEvent EVENT_GADGETMENU,index,0,point[0],point[1],item.extra
 				EndIf
 			'Return true to tell the OS not to send individual LVN_DELETEITEM notifications for each and every item when clearing list.
 			Case LVN_DELETEALLITEMS
@@ -4062,12 +4065,12 @@ Type TWindowsTextField Extends TWindowsGadget
 			Case WM_ERASEBKGND
 				Return 1
 			Case WM_KEYDOWN
-				If eventfilter<>Null
+				If eventfilter<>TGadget.NullEventFilter
 					event=CreateEvent(EVENT_KEYDOWN,Self,Int(wp),keymods())
 					If Not eventfilter(event,context) Return True
 				EndIf
 			Case WM_CHAR
-				If eventfilter<>Null
+				If eventfilter<>TGadget.NullEventFilter
 					event=CreateEvent(EVENT_KEYCHAR,Self,Int(wp),keymods())
 					If Not eventfilter(event,context) Return True
 				EndIf
@@ -4576,14 +4579,14 @@ End Rem
 						EndIf
 
 						'Event Filter
-						If eventfilter<>Null
+						If eventfilter<>TGadget.NullEventFilter
 							event=CreateEvent(EVENT_KEYDOWN,Self,k,keymods())
 							Return Not eventfilter(event,context)
 						EndIf
 
 					Case WM_CHAR
 						If _readonly Return 1
-						If eventfilter<>Null
+						If eventfilter<>TGadget.NullEventFilter
 							event=CreateEvent(EVENT_KEYCHAR,Self,Int(bmx_win32_MSGFILTER_wParam(nmhdrPtr)),keymods())
 							Return Not eventfilter(event,context)
 						EndIf


### PR DESCRIPTION
Replace direct BlitzMax gadget-layout access with opaque native peers and normalise Cocoa widget lifecycle, geometry, state, events, item models, drag and drop, menus, toolbars, tabs, text controls, and appearance behaviour.

Modernise the active AppKit implementations while retaining the synchronous legacy WebView for this release, add portable and focused native conformance coverage, document release validation, and align the related portable and Windows contracts found during cross-driver testing.